### PR TITLE
Fix typos in docs for Signal.prototype.scale

### DIFF
--- a/lib/p5.sound.js
+++ b/lib/p5.sound.js
@@ -3402,8 +3402,8 @@ signal = function () {
    *  @param {Number} number to multiply
    *  @param  {Number} inMin  input range minumum
    *  @param  {Number} inMax  input range maximum
-   *  @param  {Number} outMin input range minumum
-   *  @param  {Number} outMax input range maximum
+   *  @param  {Number} outMin output range minumum
+   *  @param  {Number} outMax output range maximum
    *  @return {p5.SignalScale} object
    */
   Signal.prototype.scale = function (inMin, inMax, outMin, outMax) {


### PR DESCRIPTION
I am an audio noob so I'm not sure if this is right, but it *seems* like a typo...