### PR TITLE
changed the "very low value" that the exponential functions replace z…

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -242,7 +242,7 @@ define(function (require) {
   p5.Env.prototype.checkExpInput = function(value) {
     if (value <= 0)
     {
-      value = 0.0001;
+      value = 0.00000001;
     }
     return value;
   };


### PR DESCRIPTION
…ero with to a lower number, because it was creating audible noise in patches with many oscillators