### PR TITLE
AudioIn fixes, better oscillator memory management, saveSound can be mono

### DIFF
--- a/src/audioin.js
+++ b/src/audioin.js
@@ -20,6 +20,10 @@ define(function (require) {
    *
    *  @class p5.AudioIn
    *  @constructor
+   *  @param {Function} [errorCallback] A function to call if there is an error
+   *                                    accessing the AudioIn. For example,
+   *                                    Safari and iOS devices do not
+   *                                    currently allow microphone access.
    *  @return {Object} AudioIn
    *  @example
    *  <div><code>
@@ -35,7 +39,7 @@ define(function (require) {
    *  }
    *  </code></div>
    */
-  p5.AudioIn = function() {
+  p5.AudioIn = function(errorCallback) {
     // set up audio input
     this.input = p5sound.audiocontext.createGain();
     this.output = p5sound.audiocontext.createGain();
@@ -59,7 +63,11 @@ define(function (require) {
 
     // Some browsers let developer determine their input sources
     if (typeof window.MediaStreamTrack === 'undefined'){
-      window.alert('This browser does not support MediaStreamTrack');
+      if (errorCallback) {
+        errorCallback();
+      } else {
+        window.alert('This browser does not support AudioIn');        
+      }
     } else if (typeof window.MediaStreamTrack.getSources === 'function') {
       // Chrome supports getSources to list inputs. Dev picks default
       window.MediaStreamTrack.getSources(this._gotSources);

--- a/src/audioin.js
+++ b/src/audioin.js
@@ -124,29 +124,31 @@ define(function (require) {
       // Only get the audio stream.
       window.navigator.getUserMedia( {'audio':true},
         this._onStream = function(stream) {
-        self.stream = stream;
-        self.enabled = true;
-        // Wrap a MediaStreamSourceNode around the live input
-        self.mediaStream = p5sound.audiocontext.createMediaStreamSource(stream);
-        self.mediaStream.connect(self.output);
-        // only send to the Amplitude reader, so we can see it but not hear it.
-        self.amplitude.setInput(self.output);
-        if (successCallback) successCallback();
-      }, this._onStreamError = function(e) {
-        if (errorCallback) errorCallback(e);
-        else console.error(e);
-      });
+          self.stream = stream;
+          self.enabled = true;
+          // Wrap a MediaStreamSourceNode around the live input
+          self.mediaStream = p5sound.audiocontext.createMediaStreamSource(stream);
+          self.mediaStream.connect(self.output);
+          // only send to the Amplitude reader, so we can see it but not hear it.
+          self.amplitude.setInput(self.output);
+          if (successCallback) successCallback();
+        }, this._onStreamError = function(e) {
+          if (errorCallback) errorCallback(e);
+          else console.error(e);
+        });
     }
   };
 
   /**
-   *  Turn the AudioIn off. If the AudioIn is stopped, it cannot getLevel().<br/>
+   *  Turn the AudioIn off. If the AudioIn is stopped, it cannot getLevel().
+   *  If re-starting, the user may be prompted for permission access.
    *
    *  @method stop
    */
   p5.AudioIn.prototype.stop = function() {
     if (this.stream) {
-      this.stream.stop();
+      // assume only one track
+      this.stream.getTracks()[0].stop();
     }
   };
 

--- a/src/audioin.js
+++ b/src/audioin.js
@@ -16,7 +16,8 @@ define(function (require) {
    *  feedback.</p> 
    *
    *  <p><em>Note: This uses the <a href="http://caniuse.com/stream">getUserMedia/
-   *  Stream</a> API, which is not supported by certain browsers.</em></p>
+   *  Stream</a> API, which is not supported by certain browsers. Access in Chrome browser
+   *  is limited to localhost and https, but access over http may be limited.</em></p>
    *
    *  @class p5.AudioIn
    *  @constructor
@@ -85,6 +86,11 @@ define(function (require) {
    *  is not connected to p5.sound's output. So you won't hear
    *  anything unless you use the connect() method.<br/>
    *
+   *  Certain browsers limit access to the user's microphone. For example,
+   *  Chrome only allows access from localhost and over https. For this reason,
+   *  you may want to include an errorCallback—a function that is called in case
+   *  the browser won't provide mic access.
+   *
    *  @method start
    *  @param {Function} successCallback Name of a function to call on
    *                                    success.
@@ -95,6 +101,9 @@ define(function (require) {
    */
   p5.AudioIn.prototype.start = function(successCallback, errorCallback) {
     var self = this;
+
+    // if stream was already started...
+
 
     // if _gotSources() i.e. developers determine which source to use
     if (p5sound.inputSources[self.currentSource]) {

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -131,7 +131,10 @@ define(function (require) {
       var type = this.oscillator.type;
 
       // set old osc free to be garbage collected (memory)
-      this.oscillator = undefined;
+      if (this.oscillator) {
+        this.oscillator.disconnect();
+        this.oscillator = undefined;
+      }
 
       // var detune = this.oscillator.frequency.value;
       this.oscillator = p5sound.audiocontext.createOscillator();
@@ -167,7 +170,6 @@ define(function (require) {
       var t = time || 0;
       var now = p5sound.audiocontext.currentTime;
       this.oscillator.stop(t + now);
-      this.oscillator.disconnect();
       this.started = false;
     }
   };

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -85,8 +85,8 @@ define(function (require) {
     this.phaseAmount = undefined;
     this.oscillator = p5sound.audiocontext.createOscillator();
     this.f = freq || 440.0; // frequency
-    this.oscillator.frequency.setValueAtTime(this.f, p5sound.audiocontext.currentTime);
     this.oscillator.type = type || 'sine';
+    this.oscillator.frequency.setValueAtTime(this.f, p5sound.audiocontext.currentTime);
 
     var o = this.oscillator;
 
@@ -129,6 +129,10 @@ define(function (require) {
     if (!this.started){
       var freq = f || this.f;
       var type = this.oscillator.type;
+
+      // set old osc free to be garbage collected (memory)
+      this.oscillator = undefined;
+
       // var detune = this.oscillator.frequency.value;
       this.oscillator = p5sound.audiocontext.createOscillator();
       this.oscillator.frequency.exponentialRampToValueAtTime(Math.abs(freq), p5sound.audiocontext.currentTime);
@@ -164,7 +168,6 @@ define(function (require) {
       var now = p5sound.audiocontext.currentTime;
       this.oscillator.stop(t + now);
       this.oscillator.disconnect();
-      this.oscillator = undefined;
       this.started = false;
     }
   };

--- a/src/soundRecorder.js
+++ b/src/soundRecorder.js
@@ -252,8 +252,16 @@ define(function (require) {
    *  @param  {String} name      name of the resulting .wav file.
    */
   p5.prototype.saveSound = function(soundFile, name) {
-    var leftChannel = soundFile.buffer.getChannelData(0);
-    var rightChannel = soundFile.buffer.getChannelData(1);
+    var leftChannel, rightChannel;
+    leftChannel = soundFile.buffer.getChannelData(0);
+
+    // handle mono files
+    if (soundFile.buffer.numberOfChannels > 1) {
+      rightChannel = soundFile.buffer.getChannelData(1);
+    } else {
+      rightChannel = leftChannel;
+    }
+
     var interleaved = interleave(leftChannel,rightChannel);
 
     // create the buffer and view to create the .WAV file


### PR DESCRIPTION
- add AudioIn error handler for ios and safari
- fix audioIn stop (#105)
- add audioin documentation
- fix saveSound for stereo (#112)
- tweak oscillator memory management