### PR TITLE
Fixed WAV format in soundRecorder.js:saveSound()

### DIFF
--- a/src/soundRecorder.js
+++ b/src/soundRecorder.js
@@ -272,7 +272,7 @@ define(function (require) {
     // check spec at: https://ccrma.stanford.edu/courses/422/projects/WaveFormat/
     // RIFF chunk descriptor
     writeUTFBytes(view, 0, 'RIFF');
-    view.setUint32(4, 44 + interleaved.length * 2, true);
+    view.setUint32(4, 36 + interleaved.length * 2, true);
     writeUTFBytes(view, 8, 'WAVE');
     // FMT sub-chunk
     writeUTFBytes(view, 12, 'fmt ');


### PR DESCRIPTION
According to the WAV spec, the number that goes right after 'RIFF' is 36 + ... not 44 + ... - here's an excerpt from the spec:

    The canonical WAVE format starts with the RIFF header:
    0         4   ChunkID          Contains the letters "RIFF" in ASCII form (0x52494646 big-endian form).
    4         4   ChunkSize        36 + SubChunk2Size, or more precisely: 4 + (8 + SubChunk1Size) + (8 + SubChunk2Size) This is the size of the rest of the chunk following this number.  This is the size of the entire file in bytes minus 8 bytes for the two fields not included in this count: ChunkID and ChunkSize.