### PR TITLE
Fix/139 audio feedback

### DIFF
--- a/src/delay.js
+++ b/src/delay.js
@@ -142,8 +142,8 @@ define(function (require) {
     src.connect(this.input);
     this.leftDelay.delayTime.setValueAtTime(delayTime, this.ac.currentTime);
     this.rightDelay.delayTime.setValueAtTime(delayTime, this.ac.currentTime);
-    this._leftGain.gain.setValueAtTime(feedback, this.ac.currentTime);
-    this._rightGain.gain.setValueAtTime(feedback, this.ac.currentTime);
+    this._leftGain.gain.value = feedback;
+    this._rightGain.gain.value = feedback;
 
     if (_filter) {
       this._leftFilter.freq(_filter);
@@ -195,8 +195,8 @@ define(function (require) {
       throw new Error('Feedback value will force a positive feedback loop.');
     }
     else {
-      this._leftGain.gain.exponentialRampToValueAtTime(f, this.ac.currentTime);
-      this._rightGain.gain.exponentialRampToValueAtTime(f, this.ac.currentTime);
+      this._leftGain.gain.value = f;
+      this._rightGain.gain.value = f;
     }
   };
 

--- a/src/delay.js
+++ b/src/delay.js
@@ -7,10 +7,11 @@ define(function (require) {
    *  Delay is an echo effect. It processes an existing sound source,
    *  and outputs a delayed version of that sound. The p5.Delay can
    *  produce different effects depending on the delayTime, feedback,
-   *  filter, and type. In the example below, a feedback of 0.5 will
-   *  produce a looping delay that decreases in volume by
-   *  50% each repeat. A filter will cut out the high frequencies so
-   *  that the delay does not sound as piercing as the original source.
+   *  filter, and type. In the example below, a feedback of 0.5 (the
+   *  defaul value) will produce a looping delay that decreases in 
+   *  volume by 50% each repeat. A filter will cut out the high
+   *  frequencies so that the delay does not sound as piercing as the
+   *  original source.
    *  
    *  @class p5.Delay
    *  @constructor
@@ -109,6 +110,9 @@ define(function (require) {
 
     this._maxDelay = this.leftDelay.delayTime.maxValue;
 
+    // set initial feedback to 0.5
+    this.feedback(0.5);
+
     // add this p5.SoundFile to the soundArray
     p5sound.soundArray.push(this);
   };
@@ -178,26 +182,31 @@ define(function (require) {
    *  in a loop. The feedback amount determines how much signal to send each
    *  time through the loop. A feedback greater than 1.0 is not desirable because
    *  it will increase the overall output each time through the loop,
-   *  creating an infinite feedback loop.
+   *  creating an infinite feedback loop. The default value is 0.5
    *  
    *  @method  feedback
    *  @param {Number|Object} feedback 0.0 to 1.0, or an object such as an
    *                                  Oscillator that can be used to
    *                                  modulate this param
+   *  @returns {Number} Feedback value
+   *                                  
    */
   p5.Delay.prototype.feedback = function(f) {
     // if f is an audio node...
-    if (typeof(f) !== 'number'){
+    if (f && typeof(f) !== 'number'){
       f.connect(this._leftGain.gain);
       f.connect(this._rightGain.gain);
     }
     else if (f >= 1.0) {
       throw new Error('Feedback value will force a positive feedback loop.');
     }
-    else {
+    else if (typeof (f) === 'number') {
       this._leftGain.gain.value = f;
       this._rightGain.gain.value = f;
     }
+
+    // return value of feedback
+    return this._leftGain.gain.value;
   };
 
   /**

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -138,7 +138,7 @@ define(function (require) {
 
       // var detune = this.oscillator.frequency.value;
       this.oscillator = p5sound.audiocontext.createOscillator();
-      this.oscillator.frequency.exponentialRampToValueAtTime(Math.abs(freq), p5sound.audiocontext.currentTime);
+      this.oscillator.frequency.value = Math.abs(freq);
       this.oscillator.type = type;
       // this.oscillator.detune.value = detune;
       this.oscillator.connect(this.output);
@@ -257,8 +257,6 @@ define(function (require) {
           this.oscillator.frequency.linearRampToValueAtTime(val, tFromNow + rampTime + now);
         }
       }
-
-
 
       // reset phase if oscillator has a phase
       if (this.phaseAmount) {

--- a/test/tests/p5.Delay.js
+++ b/test/tests/p5.Delay.js
@@ -1,0 +1,25 @@
+define(['chai'],
+  function(chai) {
+
+  var expect = chai.expect;
+
+  describe('p5.Delay', function() {
+
+    it('can be created and disposed', function() {
+      var delay = new p5.Delay();
+      delay.dispose();
+    });
+
+    it('has initial feedback value of 0.5', function(){
+      var delay = new p5.Delay();
+      expect(delay.feedback()).to.equal(0.5);
+    });
+
+    it('can set feedback', function(){
+      var delay = new p5.Delay();
+      delay.feedback(0.7);
+      expect(delay.feedback()).to.be.closeTo(0.7, 0.001);
+    });
+
+  });
+});


### PR DESCRIPTION
- assign Delay feedback and Oscillator freq values with `value = ` rather than scheduling them with `setValueAtTime()` which was causing errors in Chrome (#139)
- add some simple tests for p5.Delay
- set initial feedback value for p5.Delay to 0.5 (it was 1.0)