### PR TITLE
Updated smooth function

### DIFF
--- a/src/fft.js
+++ b/src/fft.js
@@ -91,6 +91,17 @@ define(function (require) {
    *  </code></div>
    */
   p5.FFT = function(smoothing, bins) {
+    Object.defineProperty(this, 'smoothing', {
+      get: function () {
+        return this.analyser.smoothingTimeConstant;
+      },
+      set: function (s) {
+        this.analyser.smoothingTimeConstant = s || 0.8;
+      },
+      configurable: true,
+      enumerable: true
+    });
+    
     this.smoothing = smoothing || 0.8;
     this.bins = bins || 1024;
     var FFT_SIZE = bins*2 || 2048;
@@ -99,7 +110,6 @@ define(function (require) {
     // default connections to p5sound fftMeter
     p5sound.fftMeter.connect(this.analyser);
 
-    this.analyser.smoothingTimeConstant = this.smoothing;
     this.analyser.fftSize = FFT_SIZE;
 
     this.freqDomain = new Uint8Array(this.analyser.frequencyBinCount);
@@ -468,7 +478,6 @@ define(function (require) {
    */
   p5.FFT.prototype.smooth = function(s) {
     this.smoothing = s;
-    this.analyser.smoothingTimeConstant = s;
   };
 
   p5.FFT.prototype.dispose = function() {

--- a/src/fft.js
+++ b/src/fft.js
@@ -467,9 +467,7 @@ define(function (require) {
    *                               Defaults to 0.8.
    */
   p5.FFT.prototype.smooth = function(s) {
-    if (s) {
-      this.smoothing = s;
-    }
+    this.smoothing = s;
     this.analyser.smoothingTimeConstant = s;
   };
 


### PR DESCRIPTION
Calling 

```javascript
var fft = new p5.FFT();
fft.smooth(0);
console.log(fft.smoothing);
console.log(fft.analyser.smoothingTimeConstant);
```

would yeild different results. This is because the smoothing time constant would get updated always, and `fft.smoothing` wouldn't because of the way that 0 is falsey (`0 == false`).