### PR TITLE
Logic to deal with callbacks in preload

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -177,7 +177,11 @@ define(function (require) {
    *  </code></div>
    */
   p5.prototype.loadSound = function(){
-    var callback, onerror, whileLoading;
+    var path = arguments[0]; 
+    var callback;
+    var onerror;
+    var whileLoading;
+
     var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
       
     for(var i = 1; i < arguments.length; i++) {
@@ -198,9 +202,9 @@ define(function (require) {
       alert('This sketch may require a server to load external files. Please see http://bit.ly/1qcInwS');
     }
 
-    var s = new p5.SoundFile(arguments[0], function (soundFile) {
+    var s = new p5.SoundFile(path, function (sound) {
       if (typeof callback === 'function') {
-        callback(soundFile);
+        callback(sound);
       }
 
       if(decrementPreload) {

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -176,13 +176,37 @@ define(function (require) {
    *  }
    *  </code></div>
    */
-  p5.prototype.loadSound = function(path, callback, onerror, whileLoading){
+  p5.prototype.loadSound = function(){
+    var callback, onerror, whileLoading;
+    var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
+      
+    for(var i = 1; i < arguments.length; i++) {
+      var arg = arguments[i];
+      if (typeof arg === 'function' && arg !== decrementPreload) {
+        if (typeof callback === 'undefined') {
+          callback = arg;
+        } else if (typeof onerror === 'undefined') {
+          onerror = arg;
+        } else {
+          whileLoading = arg;
+        }
+      }
+    }
+    
     // if loading locally without a server
     if (window.location.origin.indexOf('file://') > -1 && window.cordova === 'undefined' ) {
       alert('This sketch may require a server to load external files. Please see http://bit.ly/1qcInwS');
     }
 
-    var s = new p5.SoundFile(path, callback, onerror, whileLoading);
+    var s = new p5.SoundFile(arguments[0], function (soundFile) {
+      if (typeof callback === 'function') {
+        callback(soundFile);
+      }
+
+      if(decrementPreload) {
+        decrementPreload();
+      }
+    }, onerror, whileLoading);
     return s;
   };
 


### PR DESCRIPTION
This is an attempt at addressing issue #97. 

Some of the other `loadX()` functions in p5.js have logic to deal with the way `preload()` pushes its `decrementPreload()` function on the end of the argument list. 

This is causing some issues when `loadSound()` is called _with_ callbacks inside of preload (see the discussion [here](https://github.com/processing/p5.js/issues/2005))

I've tried to stick to the same kind of structure as some of the other `loadX()` functions.
What it does is fill in the arguments passed to `new p5.SoundFile()` in a way that's sensitive to the possibility that decrementPreload() has been passed as an argument. In the case that it is, it's called after the callback passed by the calling code (if any).

Any feedback on this would be really appreciated.