### PR TITLE
Applying new loadXX _decrementPreload logic to loadSound

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -182,7 +182,15 @@ define(function (require) {
       alert('This sketch may require a server to load external files. Please see http://bit.ly/1qcInwS');
     }
 
-    var s = new p5.SoundFile(path, callback, onerror, whileLoading);
+    var self = this;
+    var s = new p5.SoundFile(path, function() {
+      if(typeof callback === 'function') {
+        callback.apply(self, arguments);
+      }
+
+      self._decrementPreload();
+    }, onerror, whileLoading);
+
     return s;
   };
 


### PR DESCRIPTION
Fixes #193.

This PR applies the logic in https://github.com/processing/p5.js/pull/2008 to the `loadSound()` function.

There is a full discussion of the issue in the main p5.js library's issue queue, including an example of how the current implementation breaks, at https://github.com/processing/p5.js/issues/2005#issuecomment-309017764.


