### PR TITLE
update documentation

### DIFF
--- a/src/effect.js
+++ b/src/effect.js
@@ -5,6 +5,13 @@ define(function (require) {
   var p5sound = require('master');
   var CrossFade = require('Tone/component/CrossFade');
 
+  /**
+   *  p5.Effect is the superclass for p5 effects including Filter and Reverb.
+   *  All p5 effects share this API.
+   *
+   *  @class p5.Effect
+   *  @constructor
+   */
   p5.Effect = function() {
     this.ac = p5sound.audiocontext;
 
@@ -114,7 +121,7 @@ define(function (require) {
    *  May be used with open-ended number of arguments
    *
    *  @method chain
-     *  @param {Object} arguments p5.Effect objects
+   *  @param {Object} arguments p5.Effect objects
    */
   p5.Effect.prototype.chain = function() {
     if (arguments.length>0) {

--- a/src/errorHandler.js
+++ b/src/errorHandler.js
@@ -1,23 +1,24 @@
 'use strict';
 
 define(function () {
-  /**
-   *  Helper function to generate an error
-   *  with a custom stack trace that points to the sketch
-   *  and removes other parts of the stack trace.
-   *
-   *  @private
-   *
-   *  @param  {String} name         custom  error name
-   *  @param  {String} errorTrace   custom error trace
-   *  @param  {String} failedPath     path to the file that failed to load
-   *  @property {String} name custom error name
-   *  @property {String} message custom error message
-   *  @property {String} stack trace the error back to a line in the user's sketch.
-   *                           Note: this edits out stack trace within p5.js and p5.sound.
-   *  @property {String} originalStack unedited, original stack trace
-   *  @property {String} failedPath path to the file that failed to load
-   *  @return {Error}     returns a custom Error object
+  /*
+    Helper function to generate an error
+    with a custom stack trace that points to the sketch
+    and removes other parts of the stack trace.
+
+    @private
+    @class customError
+    @constructor
+    @param  {String} name         custom  error name
+    @param  {String} errorTrace   custom error trace
+    @param  {String} failedPath     path to the file that failed to load
+    @property {String} name custom error name
+    @property {String} message custom error message
+    @property {String} stack trace the error back to a line in the user's sketch.
+                             Note: this edits out stack trace within p5.js and p5.sound.
+    @property {String} originalStack unedited, original stack trace
+    @property {String} failedPath path to the file that failed to load
+    @return {Error}     returns a custom Error object
    */
   var CustomError = function(name, errorTrace, failedPath) {
     var err = new Error();

--- a/src/gain.js
+++ b/src/gain.js
@@ -3,7 +3,6 @@
 define(function (require) {
   var p5sound = require('master');
   require('sndcore');
-  
 
   /**
    *  A gain node is usefull to set the relative volume of sound.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -73,7 +73,8 @@ define(function (require) {
    *  converter.
    *
    *  @method soundFormats
-   *  @param {String|Strings} formats i.e. 'mp3', 'wav', 'ogg'
+   *  @param {String} formats i.e. 'mp3', 'wav', 'ogg'
+   *  @param {String} formats i.e. 'mp3', 'wav', 'ogg'
    *  @example
    *  <div><code>
    *  function preload() {
@@ -81,7 +82,7 @@ define(function (require) {
    *    soundFormats('mp3', 'ogg');
    *
    *    // load either beatbox.mp3, or .ogg, depending on browser
-   *    mySound = loadSound('../sounds/beatbox.mp3');
+   *    mySound = loadSound('assets/beatbox.mp3');
    *  }
    *
    *  function setup() {

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -48,6 +48,7 @@ define(function (require) {
    *  <div><code>
    *
    *  function preload() {
+   *    soundFormats('mp3', 'ogg');
    *    mySound = loadSound('assets/doorbell.mp3');
    *  }
    *


### PR DESCRIPTION
This fixes a few issues in documentation that is parsed via p5's `grunt yui:docs` task and eventually appears on the p5js.org web reference:

- fix incorrect file path in soundFormats example
- fix #181 by using soundFormats in the SoundFile example 
-  p5.Effect didn't have a `@class` and `@constructor`, this led p5's `grunt yui:docs` task to trip when it saw what it thought was a duplicate definition of that module's `amp` method, thinking it belonged to a different module.
- the doc block in errorHandler was not completely ignored by yui, leading to some strange output on the p5js.org website 

![image](https://user-images.githubusercontent.com/504124/27720244-95bb7eb4-5d26-11e7-9eca-507c18534b02.png)
