### PR TITLE
yuidoc @type fixes

### DIFF
--- a/src/audioin.js
+++ b/src/audioin.js
@@ -91,9 +91,9 @@ define(function (require) {
    *  the browser won't provide mic access.
    *
    *  @method start
-   *  @param {Function} successCallback Name of a function to call on
+   *  @param {Function} [successCallback] Name of a function to call on
    *                                    success.
-   *  @param {Function} errorCallback Name of a function to call if
+   *  @param {Function} [errorCallback] Name of a function to call if
    *                                    there was an error. For example,
    *                                    some browsers do not support
    *                                    getUserMedia.

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -64,16 +64,10 @@ define(function (require) {
   };
 
 
-
   /**
-   * Setter and Getter methdds 
-   * @method  {attack} set attack w/ time ramp or get current attack
-   * @method  {knee} set knee w/ time ramp or get current knee
-   * @method {ratio} set ratio w/ time ramp or get current ratio
-   * @method {threshold} set threshold w/ time ramp or get current threshold
-   * @method {release} set release w/ time ramp or get current release
+   * set attack w/ time ramp or get current attack
+   * @method attack
    */
-
   p5.Compressor.prototype.attack = function (attack, time){
     var t = time || 0;
     if (typeof attack == 'number'){
@@ -87,6 +81,10 @@ define(function (require) {
   };
 
 
+ /**
+   * set knee w/ time ramp or get current knee
+   * @method knee
+   */
   p5.Compressor.prototype.knee = function (knee, time){
     var t = time || 0;
     if (typeof knee == 'number'){
@@ -100,6 +98,10 @@ define(function (require) {
   };
 
 
+  /**
+   * set ratio w/ time ramp or get current ratio
+   * @method ratio
+   */
   p5.Compressor.prototype.ratio = function (ratio, time){
     var t = time || 0;
     if (typeof ratio == 'number'){
@@ -113,6 +115,10 @@ define(function (require) {
   };
 
 
+  /**
+   * set threshold w/ time ramp or get current threshold
+   * @method threshold
+   */
   p5.Compressor.prototype.threshold = function (threshold, time){
     var t = time || 0;
     if (typeof threshold == 'number'){
@@ -126,6 +132,10 @@ define(function (require) {
   };
 
 
+  /**
+   * set release w/ time ramp or get current release
+   * @method release
+   */
   p5.Compressor.prototype.release = function (release, time){
     var t = time || 0;
     if (typeof release == 'number'){

--- a/src/delay.js
+++ b/src/delay.js
@@ -67,8 +67,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#DelayNode">
      *  Web Audio Delay Nodes</a>, one for each stereo channel.
      *
-     *  @property leftDelay
-     *  @type {Object}  Web Audio Delay Node
+     *  @property leftDelay {Object}  Web Audio Delay Node
      */
     this.leftDelay = this.ac.createDelay();
     /**
@@ -76,8 +75,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#DelayNode">
      *  Web Audio Delay Nodes</a>, one for each stereo channel.
      *
-     *  @property rightDelay
-     *  @type {Object}  Web Audio Delay Node
+     *  @property rightDelay {Object}  Web Audio Delay Node
      */
     this.rightDelay = this.ac.createDelay();
 

--- a/src/distortion.js
+++ b/src/distortion.js
@@ -86,7 +86,6 @@ define(function (require) {
    * @param {Number} [amount=0.25] Unbounded distortion amount.
    *                                Normal values range from 0-1.
    * @param {String} [oversample='none'] 'none', '2x', or '4x'.
-   * @param {String}
    */
   p5.Distortion.prototype.set = function(amount, oversample) {
     if (amount) {

--- a/src/distortion.js
+++ b/src/distortion.js
@@ -59,8 +59,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#WaveShaperNode">
      *  Web Audio WaveShaper Node</a>.
      *
-     *  @property WaveShaperNode
-     *  @type {Object}  AudioNode
+     *  @property WaveShaperNode {Object}  AudioNode
      */
     this.waveShaperNode = this.ac.createWaveShaper();
 

--- a/src/effect.js
+++ b/src/effect.js
@@ -124,7 +124,7 @@ define(function (require) {
 	 *	May be used with open-ended number of arguments
 	 *
 	 *	@method chain 
-     *  @param {Object} arguments p5.Effect objects	
+     *  @param {Object} [...effects] p5.Effect objects	
 	 */		
 	p5.Effect.prototype.chain = function(){
 		if (arguments.length>0){

--- a/src/effect.js
+++ b/src/effect.js
@@ -23,8 +23,7 @@ define(function (require) {
 		/**
 		 *	The p5.Effect class is built
 		 * 	using Tone.js CrossFade
-		 *	@property _drywet
-		 *	@type {Object} ToneJS node
+		 *	@property _drywet {Object} ToneJS node
 		 */
 		this._drywet = new CrossFade(1);
 
@@ -32,8 +31,7 @@ define(function (require) {
 		 *	In classes that extend
 		 *	p5.Effect, connect effect nodes
 		 *	to the wet parameter
-		 *	@property wet
-		 *	@type {Object} Web Audio Gain Node
+		 *	@property wet {Object} Web Audio Gain Node
 		 */
 		this.wet = this.ac.createGain();
 

--- a/src/env.js
+++ b/src/env.js
@@ -368,7 +368,7 @@ define(function (require) {
    *  control all of them.
    *
    *  @method  setInput
-   *  @param  {Object} unit         A p5.sound object or
+   *  @param  {Object} [...inputs]         A p5.sound object or
    *                                Web Audio Param.
    */
   p5.Env.prototype.setInput = function() {

--- a/src/filter.js
+++ b/src/filter.js
@@ -86,8 +86,7 @@ define(function (require) {
       *  <a href="http://www.w3.org/TR/webaudio/#BiquadFilterNode">
       *  Web Audio BiquadFilter Node</a>.
       *
-      *  @property biquadFilter
-      *  @type {Object}  Web Audio Delay Node
+      *  @property biquadFilter {Object}  Web Audio Delay Node
 	  */
 
     this.biquad = this.ac.createBiquadFilter();
@@ -214,7 +213,8 @@ define(function (require) {
    *  its method <code>setType('lowpass')</code>.
    *  See p5.Filter for methods.
    *
-   *  @method p5.LowPass
+   *  @method LowPass
+   *  @for p5
    */
   p5.LowPass = function() {
     p5.Filter.call(this, 'lowpass');
@@ -227,7 +227,8 @@ define(function (require) {
    *  its method <code>setType('highpass')</code>.
    *  See p5.Filter for methods.
    *
-   *  @method p5.HighPass
+   *  @method HighPass
+   *  @for p5
    */
   p5.HighPass = function() {
     p5.Filter.call(this, 'highpass');
@@ -240,7 +241,8 @@ define(function (require) {
    *  its method <code>setType('bandpass')</code>.
    *  See p5.Filter for methods.
    *
-   *  @method p5.BandPass
+   *  @method BandPass
+   *  @for p5
    */
   p5.BandPass = function() {
     p5.Filter.call(this, 'bandpass');

--- a/src/filter.js
+++ b/src/filter.js
@@ -192,7 +192,7 @@ define(function (require) {
    *  "allpass".
    *
    *  @method  setType
-   *  @param {String}
+   *  @param {String} t
    */
   p5.Filter.prototype.setType = function(t) {
     this.biquad.type = t;

--- a/src/filter.js
+++ b/src/filter.js
@@ -22,7 +22,7 @@ define(function (require) {
    *
    *  @class p5.Filter
    *  @constructor
-   *  @param {[String]} type 'lowpass' (default), 'highpass', 'bandpass'
+   *  @param {String} [type] 'lowpass' (default), 'highpass', 'bandpass'
    *  @return {Object} p5.Filter
    *  @example
    *  <div><code>
@@ -108,8 +108,8 @@ define(function (require) {
    *
    *  @method  process
    *  @param  {Object} Signal  An object that outputs audio
-   *  @param {[Number]} freq Frequency in Hz, from 10 to 22050
-   *  @param {[Number]} res Resonance/Width of the filter frequency
+   *  @param {Number} [freq] Frequency in Hz, from 10 to 22050
+   *  @param {Number} [res] Resonance/Width of the filter frequency
    *                        from 0.001 to 1000
    */
   p5.Filter.prototype.process = function(src, freq, res, time) {
@@ -122,8 +122,8 @@ define(function (require) {
    *  Set the frequency and the resonance of the filter.
    *
    *  @method  set
-   *  @param {Number} freq Frequency in Hz, from 10 to 22050
-   *  @param {Number} res  Resonance (Q) from 0.001 to 1000
+   *  @param {Number} [freq] Frequency in Hz, from 10 to 22050
+   *  @param {Number} [res]  Resonance (Q) from 0.001 to 1000
    *  @param {Number} [timeFromNow] schedule this event to happen
    *                                seconds from now
    */

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -76,8 +76,7 @@ define(function (require) {
    *  converter.
    *
    *  @method soundFormats
-   *  @param {String} formats i.e. 'mp3', 'wav', 'ogg'
-   *  @param {String} formats i.e. 'mp3', 'wav', 'ogg'
+   *  @param {String} [...formats] i.e. 'mp3', 'wav', 'ogg'
    *  @example
    *  <div><code>
    *  function preload() {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,9 @@
 'use strict';
 define(function (require) {
   var p5sound = require('master');
+  /**
+   * @class p5
+   */
 
   /**
    * Returns a number representing the sample rate, in samples per second,

--- a/src/looper.js
+++ b/src/looper.js
@@ -102,8 +102,7 @@ define(function (require) {
      * strings, or an object with multiple parameters.
      * Zero (0) indicates a rest.
      *
-     * @property sequence
-     * @type {Array}
+     * @property sequence {Array}
      */
     this.sequence = sequence;
   };
@@ -390,7 +389,7 @@ define(function (require) {
    *
    *  @class p5.Score
    *  @constructor
-   *  @param {p5.Part} part(s) One or multiple parts, to be played in sequence.
+   *  @param {p5.Part} [...parts] One or multiple parts, to be played in sequence.
    *  @return {p5.Score}
    */
   p5.Score = function() {

--- a/src/master.js
+++ b/src/master.js
@@ -111,8 +111,7 @@ define(function () {
    *  Web Audio API nodes including a dyanmicsCompressor (<code>.limiter</code>),
    *  and Gain Nodes for <code>.input</code> and <code>.output</code>.
    *
-   *  @property soundOut
-   *  @type {Object}
+   *  @property soundOut {Object}
    */
   p5.prototype.soundOut = p5.soundOut = p5sound;
 

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -181,7 +181,7 @@ define(function (require) {
    *  @param {Number} [rampTime] create a fade that lasts rampTime
    *  @param {Number} [timeFromNow] schedule this event to happen
    *                                seconds from now
-   *  @return  {AudioParam} gain  If no value is provided,
+   *  @return  {p5.AudioParam} gain  If no value is provided,
    *                              returns the Web Audio API
    *                              AudioParam that controls
    *                              this oscillator's
@@ -221,7 +221,7 @@ define(function (require) {
    *  @param  {Number} [rampTime] Ramp time (in seconds)
    *  @param  {Number} [timeFromNow] Schedule this event to happen
    *                                   at x seconds from now
-   *  @return  {AudioParam} Frequency If no value is provided,
+   *  @return  {p5.AudioParam} Frequency If no value is provided,
    *                                  returns the Web Audio API
    *                                  AudioParam that controls
    *                                  this oscillator's frequency
@@ -497,7 +497,8 @@ define(function (require) {
    *  its method <code>setType('sine')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  p5.SinOsc
+   *  @method  SinOsc
+   *  @for p5
    *  @param {[Number]} freq Set the frequency
    */
   p5.SinOsc = function(freq) {
@@ -514,7 +515,8 @@ define(function (require) {
    *  its method <code>setType('triangle')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  p5.TriOsc
+   *  @method  TriOsc
+   *  @for p5
    *  @param {[Number]} freq Set the frequency
    */
   p5.TriOsc = function(freq) {
@@ -531,7 +533,8 @@ define(function (require) {
    *  its method <code>setType('sawtooth')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  p5.SawOsc
+   *  @method  SawOsc
+   *  @for p5
    *  @param {[Number]} freq Set the frequency
    */
   p5.SawOsc = function(freq) {
@@ -548,7 +551,8 @@ define(function (require) {
    *  its method <code>setType('square')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  p5.SqrOsc
+   *  @method  SqrOsc
+   *  @for p5
    *  @param {[Number]} freq Set the frequency
    */
   p5.SqrOsc = function(freq) {

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -181,7 +181,7 @@ define(function (require) {
    *  @param {Number} [rampTime] create a fade that lasts rampTime
    *  @param {Number} [timeFromNow] schedule this event to happen
    *                                seconds from now
-   *  @return  {p5.AudioParam} gain  If no value is provided,
+   *  @return  {AudioParam} gain  If no value is provided,
    *                              returns the Web Audio API
    *                              AudioParam that controls
    *                              this oscillator's
@@ -221,7 +221,7 @@ define(function (require) {
    *  @param  {Number} [rampTime] Ramp time (in seconds)
    *  @param  {Number} [timeFromNow] Schedule this event to happen
    *                                   at x seconds from now
-   *  @return  {p5.AudioParam} Frequency If no value is provided,
+   *  @return  {AudioParam} Frequency If no value is provided,
    *                                  returns the Web Audio API
    *                                  AudioParam that controls
    *                                  this oscillator's frequency
@@ -499,7 +499,7 @@ define(function (require) {
    *
    *  @method  SinOsc
    *  @for p5
-   *  @param {[Number]} freq Set the frequency
+   *  @param {Number} [freq] Set the frequency
    */
   p5.SinOsc = function(freq) {
     p5.Oscillator.call(this, freq, 'sine');
@@ -517,7 +517,7 @@ define(function (require) {
    *
    *  @method  TriOsc
    *  @for p5
-   *  @param {[Number]} freq Set the frequency
+   *  @param {Number} [freq] Set the frequency
    */
   p5.TriOsc = function(freq) {
     p5.Oscillator.call(this, freq, 'triangle');
@@ -535,7 +535,7 @@ define(function (require) {
    *
    *  @method  SawOsc
    *  @for p5
-   *  @param {[Number]} freq Set the frequency
+   *  @param {Number} [freq] Set the frequency
    */
   p5.SawOsc = function(freq) {
     p5.Oscillator.call(this, freq, 'sawtooth');
@@ -553,7 +553,7 @@ define(function (require) {
    *
    *  @method  SqrOsc
    *  @for p5
-   *  @param {[Number]} freq Set the frequency
+   *  @param {Number} [freq] Set the frequency
    */
   p5.SqrOsc = function(freq) {
     p5.Oscillator.call(this, freq, 'square');

--- a/src/peakDetect.js
+++ b/src/peakDetect.js
@@ -114,8 +114,7 @@ define(function () {
     /**
      *  isDetected is set to true when a peak is detected.
      *
-     *  @attribute isDetected
-     *  @type {Boolean}
+     *  @attribute isDetected {Boolean}
      *  @default  false
      */
     this.isDetected = false;

--- a/src/reverb.js
+++ b/src/reverb.js
@@ -234,8 +234,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#ConvolverNode">
      *  Web Audio Convolver Node</a>.
      *
-     *  @property convolverNode
-     *  @type {Object}  Web Audio Convolver Node
+     *  @property convolverNode {Object}  Web Audio Convolver Node
      */
     this.convolverNode = this.ac.createConvolver();
 
@@ -432,8 +431,7 @@ define(function (require) {
    *  they will be stored as Objects in this Array. Toggle between them
    *  with the <code>toggleImpulse(id)</code> method.
    *
-   *  @property impulses
-   *  @type {Array} Array of Web Audio Buffers
+   *  @property impulses {Array} Array of Web Audio Buffers
    */
   p5.Convolver.prototype.impulses = [];
 

--- a/src/signal.js
+++ b/src/signal.js
@@ -64,7 +64,7 @@ define(function (require) {
    *
    *  @method  fade
    *  @param  {Number} value          Value to set this signal
-   *  @param  {[Number]} secondsFromNow Length of fade, in seconds from now
+   *  @param  {Number} [secondsFromNow] Length of fade, in seconds from now
    */
   Signal.prototype.fade = Signal.prototype.linearRampToValueAtTime;
   Mult.prototype.fade =   Signal.prototype.fade;

--- a/src/soundRecorder.js
+++ b/src/soundRecorder.js
@@ -92,7 +92,7 @@ define(function (require) {
     /**
      *  callback invoked when the recording is over
      *  @private
-     *  @type {function(Float32Array)}
+     *  @type Function(Float32Array)
      */
     this._callback = function() {};
 

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -25,7 +25,7 @@ define(function (require) {
    *
    *  @class p5.SoundFile
    *  @constructor
-   *  @param {String/Array} path   path to a sound file (String). Optionally,
+   *  @param {String|Array} path   path to a sound file (String). Optionally,
    *                               you may include multiple file formats in
    *                               an array. Alternately, accepts an object
    *                               from the HTML5 File API, or a p5.File.
@@ -153,7 +153,7 @@ define(function (require) {
    *  local server</a> is recommended when loading external files.
    *
    *  @method loadSound
-   *  @param  {String/Array}   path     Path to the sound file, or an array with
+   *  @param  {String|Array}   path     Path to the sound file, or an array with
    *                                    paths to soundfiles in multiple formats
    *                                    i.e. ['sound.ogg', 'sound.mp3'].
    *                                    Alternately, accepts an object: either

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -723,8 +723,8 @@ define(function (require) {
    *
    * @method pan
    * @param {Number} [panValue]     Set the stereo panner
-   * @param  {Number} timeFromNow schedule this event to happen
-   *                                seconds from now
+   * @param {Number} [timeFromNow]  schedule this event to happen
+   *                                 seconds from now
    * @example
    * <div><code>
    *


### PR DESCRIPTION
this fixes a few issues with the yuidoc @type declarations. mostly, `@type` doesn't use '{}' or take a description (even though the yuidoc docs suggest it does). also a few p5 namespace fixes.