### PR TITLE
docs: remove @returns from @constructors, add @extends

### DIFF
--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -13,7 +13,6 @@ define(function (require) {
    *  @constructor
    *  @param {Number} [smoothing] between 0.0 and .999 to smooth
    *                             amplitude readings (defaults to 0)
-   *  @return {Object}    Amplitude Object
    *  @example
    *  <div><code>
    *  var sound, amplitude, cnv;

--- a/src/audioin.js
+++ b/src/audioin.js
@@ -24,7 +24,6 @@ define(function (require) {
    *                                    accessing the AudioIn. For example,
    *                                    Safari and iOS devices do not
    *                                    currently allow microphone access.
-   *  @return {Object} AudioIn
    *  @example
    *  <div><code>
    *  var mic;

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -18,8 +18,8 @@ define(function (require) {
    * https://www.w3.org/TR/webaudio/#the-dynamicscompressornode-interface
    *
    * @class p5.Compressor
+   * @extends p5.Effect
    * @constructor
-   * @return {Object} Returns a p5.Compressor object
    *
    * @example
    * <div><code>

--- a/src/delay.js
+++ b/src/delay.js
@@ -15,8 +15,8 @@ define(function (require) {
    *  original source.
    *
    *  @class p5.Delay
+   *  @extends p5.Effect
    *  @constructor
-   *  @return {Object} Returns a p5.Delay object
    *  @example
    *  <div><code>
    *  var noise, env, delay;

--- a/src/delay.js
+++ b/src/delay.js
@@ -67,7 +67,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#DelayNode">
      *  Web Audio Delay Nodes</a>, one for each stereo channel.
      *
-     *  @property leftDelay {Object}  Web Audio Delay Node
+     *  @property {DelayNode} leftDelay
      */
     this.leftDelay = this.ac.createDelay();
     /**
@@ -75,7 +75,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#DelayNode">
      *  Web Audio Delay Nodes</a>, one for each stereo channel.
      *
-     *  @property rightDelay {Object}  Web Audio Delay Node
+     *  @property {DelayNode} rightDelay
      */
     this.rightDelay = this.ac.createDelay();
 

--- a/src/distortion.js
+++ b/src/distortion.js
@@ -59,7 +59,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#WaveShaperNode">
      *  Web Audio WaveShaper Node</a>.
      *
-     *  @property WaveShaperNode {Object}  AudioNode
+     *  @property {AudioNode} WaveShaperNode
      */
     this.waveShaperNode = this.ac.createWaveShaper();
 

--- a/src/distortion.js
+++ b/src/distortion.js
@@ -27,12 +27,12 @@ define(function (require) {
    * [Kevin Ennis](http://stackoverflow.com/questions/22312841/waveshaper-node-in-webaudio-how-to-emulate-distortion)
    *
    * @class p5.Distortion
+   * @extends p5.Effect
    * @constructor
    * @param {Number} [amount=0.25] Unbounded distortion amount.
    *                                Normal values range from 0-1.
    * @param {String} [oversample='none'] 'none', '2x', or '4x'.
    *
-   * @return {Object}   Distortion object
    */
   p5.Distortion = function(amount, oversample) {
     Effect.call(this);

--- a/src/effect.js
+++ b/src/effect.js
@@ -22,7 +22,7 @@ define(function (require) {
 		/**
 		 *	The p5.Effect class is built
 		 * 	using Tone.js CrossFade
-		 *	@property _drywet {Object} ToneJS node
+		 *	@property {CrossFade} _drywet
 		 */
 		this._drywet = new CrossFade(1);
 
@@ -30,7 +30,7 @@ define(function (require) {
 		 *	In classes that extend
 		 *	p5.Effect, connect effect nodes
 		 *	to the wet parameter
-		 *	@property wet {Object} Web Audio Gain Node
+		 *	@property {GainNode} wet
 		 */
 		this.wet = this.ac.createGain();
 

--- a/src/effect.js
+++ b/src/effect.js
@@ -11,7 +11,6 @@ define(function (require) {
 	 *
 	 * @class  p5.Effect
 	 * @constructor
-	 * @return {Object} Returns a p5.Effect object
 	 * 
 	 */
 	p5.Effect = function() {

--- a/src/errorHandler.js
+++ b/src/errorHandler.js
@@ -36,7 +36,7 @@ define(function () {
     });
     err.stack = splitStack.join('\n');
 
-    return err;
+    return err; // TODO: is this really a constructor?
   };
 
   return CustomError;

--- a/src/fft.js
+++ b/src/fft.js
@@ -39,7 +39,6 @@ define(function (require) {
    *  @param {Number} [bins]    Length of resulting array.
    *                            Must be a power of two between
    *                            16 and 1024. Defaults to 1024.
-   *  @return {Object}    FFT Object
    *  @example
    *  <div><code>
    *  function preload(){

--- a/src/filter.js
+++ b/src/filter.js
@@ -21,9 +21,9 @@ define(function (require) {
    *  bandpass, or resonance of the low/highpass cutoff frequency.
    *
    *  @class p5.Filter
+   *  @extends p5.Effect
    *  @constructor
    *  @param {String} [type] 'lowpass' (default), 'highpass', 'bandpass'
-   *  @return {Object} p5.Filter
    *  @example
    *  <div><code>
    *  var fft, noise, filter;

--- a/src/filter.js
+++ b/src/filter.js
@@ -86,7 +86,7 @@ define(function (require) {
       *  <a href="http://www.w3.org/TR/webaudio/#BiquadFilterNode">
       *  Web Audio BiquadFilter Node</a>.
       *
-      *  @property biquadFilter {Object}  Web Audio Delay Node
+      *  @property {DelayNode} biquadFilter
 	  */
 
     this.biquad = this.ac.createBiquadFilter();

--- a/src/looper.js
+++ b/src/looper.js
@@ -102,7 +102,7 @@ define(function (require) {
      * strings, or an object with multiple parameters.
      * Zero (0) indicates a rest.
      *
-     * @property sequence {Array}
+     * @property {Array} sequence
      */
     this.sequence = sequence;
   };

--- a/src/looper.js
+++ b/src/looper.js
@@ -390,7 +390,6 @@ define(function (require) {
    *  @class p5.Score
    *  @constructor
    *  @param {p5.Part} [...parts] One or multiple parts, to be played in sequence.
-   *  @return {p5.Score}
    */
   p5.Score = function() {
     // for all of the arguments

--- a/src/master.js
+++ b/src/master.js
@@ -111,7 +111,7 @@ define(function () {
    *  Web Audio API nodes including a dyanmicsCompressor (<code>.limiter</code>),
    *  and Gain Nodes for <code>.input</code> and <code>.output</code>.
    *
-   *  @property soundOut {Object}
+   *  @property {Object} soundOut
    */
   p5.prototype.soundOut = p5.soundOut = p5sound;
 

--- a/src/noise.js
+++ b/src/noise.js
@@ -7,10 +7,10 @@ define(function (require) {
    *  Noise is a type of oscillator that generates a buffer with random values.
    *
    *  @class p5.Noise
+   *  @extends p5.Oscillator
    *  @constructor
    *  @param {String} type Type of noise can be 'white' (default),
    *                       'brown' or 'pink'.
-   *  @return {Object}    Noise Object
    */
   p5.Noise = function(type) {
     var assignType;

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -29,7 +29,6 @@ define(function (require) {
    *  @param {String} [type] type of oscillator. Options:
    *                         'sine' (default), 'triangle',
    *                         'sawtooth', 'square'
-   *  @return {Object}    Oscillator object
    *  @example
    *  <div><code>
    *  var osc;

--- a/src/pulse.js
+++ b/src/pulse.js
@@ -15,6 +15,7 @@ define(function (require) {
    *  <code>p5.Oscillator</code> for a full list of methods.
    *
    *  @class p5.Pulse
+   *  @extends p5.Oscillator
    *  @constructor
    *  @param {Number} [freq] Frequency in oscillations per second (Hz)
    *  @param {Number} [w]    Width between the pulses (0 to 1.0,

--- a/src/reverb.js
+++ b/src/reverb.js
@@ -15,6 +15,7 @@ define(function (require) {
    *  spaces through convolution.
    *
    *  @class p5.Reverb
+   *  @extends p5.Effect
    *  @constructor
    *  @example
    *  <div><code>
@@ -191,6 +192,7 @@ define(function (require) {
    *  p5.Convolver with a path to your impulse response audio file.</p>
    *
    *  @class p5.Convolver
+   *  @extends p5.Effect
    *  @constructor
    *  @param  {String}   path     path to a sound file
    *  @param  {Function} [callback] function to call when loading succeeds

--- a/src/reverb.js
+++ b/src/reverb.js
@@ -236,7 +236,7 @@ define(function (require) {
      *  <a href="http://www.w3.org/TR/webaudio/#ConvolverNode">
      *  Web Audio Convolver Node</a>.
      *
-     *  @property convolverNode {Object}  Web Audio Convolver Node
+     *  @property {ConvolverNode} convolverNod
      */
     this.convolverNode = this.ac.createConvolver();
 
@@ -433,7 +433,7 @@ define(function (require) {
    *  they will be stored as Objects in this Array. Toggle between them
    *  with the <code>toggleImpulse(id)</code> method.
    *
-   *  @property impulses {Array} Array of Web Audio Buffers
+   *  @property {Array} impulses
    */
   p5.Convolver.prototype.impulses = [];
 

--- a/src/signal.js
+++ b/src/signal.js
@@ -56,7 +56,7 @@ define(function (require) {
   p5.Signal = function(value) {
     var s = new Signal(value);
     // p5sound.soundArray.push(s);
-    return s;
+    return s; // TODO: is this really a constructor?
   };
 
   /**

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -43,7 +43,6 @@ define(function (require) {
    *                                             does not account for the additional
    *                                             time needed to decode the audio data.
    *
-   *  @return {Object}    p5.SoundFile Object
    *  @example
    *  <div><code>
    *


### PR DESCRIPTION
this one cleans up the constructors a little and adds `@extends` where appropriate. constructors actually return void, so i removed the `@return` attributes from them.

i also modified the item view template to render a fake **'Returns:'** section for constructors:

https://github.com/Spongman/p5.js/commit/631439cb9ffba0a7127968115724f121e0ae234c
