### PR TITLE
Docs subclasses

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,11 @@ module.exports = function(grunt) {
       main: {
         files: ['src/**/*.js'],
         tasks: ['requirejs'],
-        options: { livereload: true }
+        options: {
+          livereload: {
+            port: 35728
+          }
+        },
       }
     },
     requirejs: {
@@ -144,6 +148,7 @@ module.exports = function(grunt) {
       server: {
         options: {
           port: 8000,
+          livereload: 35727,
           hostname: '*'
         }
       }

--- a/src/filter.js
+++ b/src/filter.js
@@ -5,17 +5,17 @@ define(function (require) {
   var Effect = require('effect');
 
   /**
-   *  A p5.Filter uses a Web Audio Biquad Filter to filter
-   *  the frequency response of an input source. Inheriting
-   *  classes include:<br/>
-   *  * <code>p5.LowPass</code> - allows frequencies below
-   *  the cutoff frequency to pass through, and attenuates
-   *  frequencies above the cutoff.<br/>
-   *  * <code>p5.HighPass</code> - the opposite of a lowpass
-   *  filter. <br/>
-   *  * <code>p5.BandPass</code> -  allows a range of
-   *  frequencies to pass through and attenuates the frequencies
-   *  below and above this frequency range.<br/>
+   *  <p>A p5.Filter uses a Web Audio Biquad Filter to filter
+   *  the frequency response of an input source. Subclasses
+   *  include:</p>
+   *  * <a href="/reference/#/p5.LowPass"><code>p5.LowPass</code></a>:
+   *  Allows frequencies below the cutoff frequency to pass through,
+   *  and attenuates frequencies above the cutoff.<br/>
+   *  * <a href="/reference/#/p5.HighPass"><code>p5.HighPass</code></a>:
+   *  The opposite of a lowpass filter. <br/>
+   *  * <a href="/reference/#/p5.BandPass"><code>p5.BandPass</code></a>:
+   *  Allows a range of frequencies to pass through and attenuates
+   *  the frequencies below and above this frequency range.<br/>
    *
    *  The <code>.res()</code> method controls either width of the
    *  bandpass, or resonance of the low/highpass cutoff frequency.
@@ -213,8 +213,9 @@ define(function (require) {
    *  its method <code>setType('lowpass')</code>.
    *  See p5.Filter for methods.
    *
-   *  @method LowPass
-   *  @for p5
+   *  @class p5.LowPass
+   *  @constructor
+   *  @extends {p5.Filter}
    */
   p5.LowPass = function() {
     p5.Filter.call(this, 'lowpass');
@@ -227,8 +228,9 @@ define(function (require) {
    *  its method <code>setType('highpass')</code>.
    *  See p5.Filter for methods.
    *
-   *  @method HighPass
-   *  @for p5
+   *  @class p5.HighPass
+   *  @constructor
+   *  @extends {p5.Filter}
    */
   p5.HighPass = function() {
     p5.Filter.call(this, 'highpass');
@@ -241,8 +243,9 @@ define(function (require) {
    *  its method <code>setType('bandpass')</code>.
    *  See p5.Filter for methods.
    *
-   *  @method BandPass
-   *  @for p5
+   *  @class BandPass
+   *  @constructor
+   *  @extends {p5.Filter}
    */
   p5.BandPass = function() {
     p5.Filter.call(this, 'bandpass');

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -15,12 +15,11 @@ define(function (require) {
    *  440 oscillations per second (440Hz, equal to the pitch of an
    *  'A' note).</p>
    *
-   *  <p>Set the type of oscillation with setType(), or by creating a
-   *  specific oscillator.</p> For example:
-   *  <code>new p5.SinOsc(freq)</code>
-   *  <code>new p5.TriOsc(freq)</code>
-   *  <code>new p5.SqrOsc(freq)</code>
-   *  <code>new p5.SawOsc(freq)</code>.
+   *  <p>Set the type of oscillation with setType(), or by instantiating a
+   *  specific oscillator: <a href="/reference/#/p5.SinOsc">p5.SinOsc</a>, <a
+   *  href="/reference/#/p5.TriOsc">p5.TriOsc</a>, <a
+   *  href="/reference/#/p5.SqrOsc">p5.SqrOsc</a>, or <a
+   *  href="/reference/#/p5.SawOsc">p5.SawOsc</a>.
    *  </p>
    *
    *  @class p5.Oscillator
@@ -496,8 +495,9 @@ define(function (require) {
    *  its method <code>setType('sine')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  SinOsc
-   *  @for p5
+   *  @class  p5.SinOsc
+   *  @constructor
+   *  @extends {p5.Oscillator}
    *  @param {Number} [freq] Set the frequency
    */
   p5.SinOsc = function(freq) {
@@ -514,8 +514,9 @@ define(function (require) {
    *  its method <code>setType('triangle')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  TriOsc
-   *  @for p5
+   *  @class  p5.TriOsc
+   *  @constructor
+   *  @extends {p5.Oscillator}
    *  @param {Number} [freq] Set the frequency
    */
   p5.TriOsc = function(freq) {
@@ -532,8 +533,9 @@ define(function (require) {
    *  its method <code>setType('sawtooth')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  SawOsc
-   *  @for p5
+   *  @class  p5.SawOsc
+   *  @constructor
+   *  @extends {p5.Oscillator}
    *  @param {Number} [freq] Set the frequency
    */
   p5.SawOsc = function(freq) {
@@ -550,8 +552,9 @@ define(function (require) {
    *  its method <code>setType('square')</code>.
    *  See p5.Oscillator for methods.
    *
-   *  @method  SqrOsc
-   *  @for p5
+   *  @class  p5.SqrOsc
+   *  @constructor
+   *  @extends {p5.Oscillator}
    *  @param {Number} [freq] Set the frequency
    */
   p5.SqrOsc = function(freq) {


### PR DESCRIPTION
- Grunt watch and connect tasks use different ports than p5.js-website's watch task so that we can run both at the same time
- update docs for subclasses of filter and oscillator (following up on https://github.com/processing/p5.js-sound/pull/199#discussion_r126860732)