### PR TITLE
Update docs again

### DIFF
--- a/src/compressor.js
+++ b/src/compressor.js
@@ -90,6 +90,8 @@ define(function (require) {
 
   /**
    * Get current attack or set value w/ time ramp
+   * 
+   * 
    * @method attack
    * @param {Number} [attack] Attack is the amount of time (in seconds) to reduce the gain by 10dB,
    *                          default = .003, range 0 - 1
@@ -110,6 +112,7 @@ define(function (require) {
 
  /**
    * Get current knee or set value w/ time ramp
+   * 
    * @method knee
    * @param {Number} [knee] A decibel value representing the range above the 
    *                        threshold where the curve smoothly transitions to the "ratio" portion.

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -90,8 +90,6 @@ define(function (require) {
 
   /**
    * Get current attack or set value w/ time ramp
-   * 
-   * 
    * @method attack
    * @param {Number} [attack] Attack is the amount of time (in seconds) to reduce the gain by 10dB,
    *                          default = .003, range 0 - 1
@@ -112,7 +110,6 @@ define(function (require) {
 
  /**
    * Get current knee or set value w/ time ramp
-   * 
    * @method knee
    * @param {Number} [knee] A decibel value representing the range above the 
    *                        threshold where the curve smoothly transitions to the "ratio" portion.

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -13,15 +13,16 @@ define(function (require) {
    * Compression can be used to avoid clipping (sound distortion due to 
    * peaks in volume) and is especially useful when many sounds are played 
    * at once. Compression can be used on indivudal sound sources in addition
-   * to the master output. This class is built using the 
-   * Web Audio Dynamics Compressor Node 
-   * <a href="https://www.w3.org/TR/webaudio/#the-dynamicscompressornode-interface" 
-   *   target="_blank" title="W3 spec for Dynamics Compressor Node">Web Audio Dynamics Compressor Node
-   *   </a>
+   * to the master output.  
+   *
+   * This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
+   * Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
+   * <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   * <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
    *
    * @class p5.Compressor
-   * @extends {p5.Effect}
    * @constructor
+   * @extends p5.Effect
    *
    * 
    */
@@ -29,8 +30,13 @@ define(function (require) {
 		Effect.call(this);
 
     /**
-     * @property {WebAudioNode} compressor  DynamicsCompressorNode instance
+     * The p5.Compressor is built with a <a href="https://www.w3.org/TR/webaudio/#the-dynamicscompressornode-interface" 
+   *   target="_blank" title="W3 spec for Dynamics Compressor Node">Web Audio Dynamics Compressor Node
+   *   </a>
+     * @property {WebAudioNode} compressor 
      */
+    
+
 		this.compressor = this.ac.createDynamicsCompressor();
 
     this.input.connect(this.compressor);
@@ -43,17 +49,19 @@ define(function (require) {
   * Performs the same function as .connect, but also accepts
   * optional parameters to set compressor's audioParams
   * @method process 
+  *
+  * @param {Object} src         Sound source to be connected
   * 
-  * @param {Number} attack     The amount of time (in seconds) to reduce the gain by 10dB,
+  * @param {Number} [attack]     The amount of time (in seconds) to reduce the gain by 10dB,
   *                            default = .003, range 0 - 1
-  * @param {Number} knee       A decibel value representing the range above the 
+  * @param {Number} [knee]       A decibel value representing the range above the 
   *                            threshold where the curve smoothly transitions to the "ratio" portion.
   *                            default = 30, range 0 - 40
-  * @param {Number} ratio      The amount of dB change in input for a 1 dB change in output
+  * @param {Number} [ratio]      The amount of dB change in input for a 1 dB change in output
   *                            default = 12, range 1 - 20
-  * @param {Number} threshold  The decibel value above which the compression will start taking effect
+  * @param {Number} [threshold]  The decibel value above which the compression will start taking effect
   *                            default = -24, range -100 - 0
-  * @param {Number} release    The amount of time (in seconds) to increase the gain by 10dB
+  * @param {Number} [release]    The amount of time (in seconds) to increase the gain by 10dB
   *                            default = .25, range 0 - 1
   */
 	p5.Compressor.prototype.process = function(src, attack, knee, 

--- a/src/delay.js
+++ b/src/delay.js
@@ -14,6 +14,11 @@ define(function (require) {
    *  frequencies so that the delay does not sound as piercing as the
    *  original source.
    *
+   *
+   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
+   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
+   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
    *  @class p5.Delay
    *  @extends p5.Effect
    *  @constructor

--- a/src/distortion.js
+++ b/src/distortion.js
@@ -25,7 +25,12 @@ define(function (require) {
    * A Distortion effect created with a Waveshaper Node,
    * with an approach adapted from
    * [Kevin Ennis](http://stackoverflow.com/questions/22312841/waveshaper-node-in-webaudio-how-to-emulate-distortion)
-   *
+   * 
+   * This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
+   * Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
+   * <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   * <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
+   * 
    * @class p5.Distortion
    * @extends p5.Effect
    * @constructor
@@ -49,11 +54,6 @@ define(function (require) {
 
     var curveAmount = p5.prototype.map(amount, 0.0, 1.0, 0, 2000);
 
-    // this.ac = p5sound.audiocontext;
-
-    // this.input = this.ac.createGain();
-    // this.output = this.ac.createGain();
-
     /**
      *  The p5.Distortion is built with a
      *  <a href="http://www.w3.org/TR/webaudio/#WaveShaperNode">
@@ -74,6 +74,15 @@ define(function (require) {
 
   p5.Distortion.prototype = Object.create(Effect.prototype);
 
+
+  /**
+   * Process a sound source, optionally specify amount and oversample values.
+   *
+   * @method process
+   * @param {Number} [amount=0.25] Unbounded distortion amount.
+   *                                Normal values range from 0-1.
+   * @param {String} [oversample='none'] 'none', '2x', or '4x'.
+   */
   p5.Distortion.prototype.process = function(src, amount, oversample) {
     src.connect(this.input);
     this.set(amount, oversample);
@@ -82,7 +91,7 @@ define(function (require) {
   /**
    * Set the amount and oversample of the waveshaper distortion.
    *
-   * @method setType
+   * @method set
    * @param {Number} [amount=0.25] Unbounded distortion amount.
    *                                Normal values range from 0-1.
    * @param {String} [oversample='none'] 'none', '2x', or '4x'.
@@ -112,33 +121,14 @@ define(function (require) {
   /**
    *  Return the oversampling.
    *
+   *  @method getOversample
+   *
    *  @return {String} Oversample can either be 'none', '2x', or '4x'.
    */
   p5.Distortion.prototype.getOversample = function() {
     return this.waveShaperNode.oversample;
   };
 
-  // DocBlocks for methods inherited from p5.Effect
-  /**
-   *  Send output to a p5.sound or web audio object
-   *
-   *  @method connect
-   *  @param  {Object} unit
-   */
-  /**
-   *  Disconnect all output.
-   *
-   *  @method disconnect
-   */
-  /**
-   *  Set the output level.
-   *
-   *  @method  amp
-   *  @param  {Number} volume amplitude between 0 and 1.0
-   *  @param {Number} [rampTime] create a fade that lasts rampTime
-   *  @param {Number} [timeFromNow] schedule this event to happen
-   *                                seconds from now
-   */
 
   p5.Distortion.prototype.dispose = function() {
     Effect.prototype.dispose.apply(this);

--- a/src/effect.js
+++ b/src/effect.js
@@ -12,7 +12,6 @@ define(function (require) {
 	 * @class  p5.Effect
 	 * @constructor
 	 *
-
 	 * @property {Object} [ac]   Reference to the audio context of the p5 object
 	 * @property {WebAudioNode} [input]  Gain Node effect wrapper
 	 * @property {WebAudioNode} [output] Gain Node effect wrapper

--- a/src/effect.js
+++ b/src/effect.js
@@ -9,15 +9,22 @@ define(function (require) {
 	 * This module handles the nodes and methods that are 
 	 * common and useful for current and future effects.
 	 *
+	 *
+	 * This class is extended by <a href="reference/#/p5.Distortion">p5.Distortion</a>, 
+	 * <a href="reference/#/p5.Compressor">p5.Compressor</a>,
+	 * <a href="reference/#/p5.Delay">p5.Delay</a>, 
+	 * <a href="reference/#/p5.Filter">p5.Filter</a>, 
+	 * <a href="reference/#/p5.Reverb">p5.Reverb</a>.
+	 *
 	 * @class  p5.Effect
 	 * @constructor
 	 *
-	 * @property {Object} [ac]   Reference to the audio context of the p5 object
-	 * @property {WebAudioNode} [input]  Gain Node effect wrapper
-	 * @property {WebAudioNode} [output] Gain Node effect wrapper
-	 * @property {Object} [_drywet]   Tone.JS CrossFade node (defaults to value: 1)
-	 * @property {WebAudioNode} [wet]  Effect that extend this class should connect
-	 *                              to this this gain node, so that dry and wet 
+	 * @param {Object} [ac]   Reference to the audio context of the p5 object
+	 * @param {WebAudioNode} [input]  Gain Node effect wrapper
+	 * @param {WebAudioNode} [output] Gain Node effect wrapper
+	 * @param {Object} [_drywet]   Tone.JS CrossFade node (defaults to value: 1)
+	 * @param {WebAudioNode} [wet]  Effects that extend this class should connect
+	 *                              to the wet signal to this gain node, so that dry and wet 
 	 *                              signals are mixed properly.
 	 */
 	p5.Effect = function() {
@@ -26,11 +33,12 @@ define(function (require) {
 		this.input = this.ac.createGain();
 		this.output = this.ac.createGain();
 
-		/**
-		 *	The p5.Effect class is built
-		 * 	using Tone.js CrossFade
-		 * 	@private
-		 */
+		 /**
+		  *	The p5.Effect class is built
+		  * 	using Tone.js CrossFade
+		  * 	@private
+		  */
+		 
 		this._drywet = new CrossFade(1);
 
 		/**

--- a/src/effect.js
+++ b/src/effect.js
@@ -12,6 +12,7 @@ define(function (require) {
 	 * @class  p5.Effect
 	 * @constructor
 	 *
+
 	 * @property {Object} [ac]   Reference to the audio context of the p5 object
 	 * @property {WebAudioNode} [input]  Gain Node effect wrapper
 	 * @property {WebAudioNode} [output] Gain Node effect wrapper

--- a/src/filter.js
+++ b/src/filter.js
@@ -20,6 +20,11 @@ define(function (require) {
    *  The <code>.res()</code> method controls either width of the
    *  bandpass, or resonance of the low/highpass cutoff frequency.
    *
+   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
+   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
+   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
+   *
    *  @class p5.Filter
    *  @extends p5.Effect
    *  @constructor

--- a/src/reverb.js
+++ b/src/reverb.js
@@ -14,6 +14,11 @@ define(function (require) {
    *  extends p5.Reverb allowing you to recreate the sound of actual physical
    *  spaces through convolution.
    *
+   *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.  
+   *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>, 
+   *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and 
+   *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
+   *
    *  @class p5.Reverb
    *  @extends p5.Effect
    *  @constructor


### PR DESCRIPTION
re-opening this PR because of some new fixes, and updated docs for all effects.

yuidoc tag @extends does not seem to render the relevant methods from the base class (does not seem to be happening for p5 either)-- have included links to base class / methods in the effect classes.