### PR TITLE
fix documentation bug

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@
 define(function (require) {
   var p5sound = require('master');
   /**
-   * @class p5
+   * @for p5
    */
 
   /**


### PR DESCRIPTION
when the combined `data.json` file is generated, the source file for the `p5` class was listed as `addons/p5.sound.js`. this is because of this bogus `@class p5` directive in `src/helpers.j`.

this PR switches this to a `@for` directive which indicated that these are additional methods for a class defined elsewhere...