### PR TITLE
Fix missing paren on p5.SoundLoop example sketch

### DIFF
--- a/src/soundLoop.js
+++ b/src/soundLoop.js
@@ -20,7 +20,7 @@ define(function (require) {
    * var looper1;
    * 
    * function preload() {
-   *   click = loadSound('assets/drum.mp3'
+   *   click = loadSound('assets/drum.mp3');
    * }
    * 
    * function setup() {


### PR DESCRIPTION
Hey all,

Noticed we were missing a paren after the loadSound call on the p5.SoundLoop example sketch. This was breaking the example and the formatting on the p5 reference site.

All the best

Dex