### PR TITLE
MonoSynth inline docs: remove loadPreset()

### DIFF
--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -19,7 +19,6 @@ define(function (require) {
     *
     *  function setup() {
     *    monosynth = new p5.MonoSynth();
-    *    monosynth.loadPreset('simpleBass');
     *    monosynth.play(45,1,x=0,1);
     *    monosynth.play(49,1,x+=1,0.25);
     *    monosynth.play(50,1,x+=0.25,0.25);


### PR DESCRIPTION
As pointed out in https://github.com/processing/p5.js-sound/issues/259#issuecomment-372107373 as well as https://github.com/processing/p5.js-sound/issues/245, there is a stray `monosynth.loadPreset('simpleBass')` method being called in the inline documentation for MonoSynth, which produces an error "monosynth.loadPreset is not a function".

This PR fixes the error by removing the line.