### PR TITLE
Preload fixes

### DIFF
--- a/src/gain.js
+++ b/src/gain.js
@@ -19,8 +19,8 @@ define(function (require) {
    *
    * function preload(){
    *   soundFormats('ogg', 'mp3');
-   *   sound1 = loadSound('../_files/Damscray_-_Dancing_Tiger_01');
-   *   sound2 = loadSound('../_files/beat.mp3');
+   *   sound1 = loadSound('assets/Damscray_-_Dancing_Tiger_01');
+   *   sound2 = loadSound('assets/beat.mp3');
    * }
    *
    * function setup() {

--- a/src/peakDetect.js
+++ b/src/peakDetect.js
@@ -48,18 +48,19 @@ define(function () {
    *  var cnv, soundFile, fft, peakDetect;
    *  var ellipseWidth = 10;
    *
+   *  function preload() {
+   *    soundFile = loadSound('assets/beat.mp3');
+   *  }
+   *
    *  function setup() {
    *    background(0);
    *    noStroke();
    *    fill(255);
    *    textAlign(CENTER);
    *
-   *    soundFile = loadSound('assets/beat.mp3');
-   *
    *    // p5.PeakDetect requires a p5.FFT
    *    fft = new p5.FFT();
    *    peakDetect = new p5.PeakDetect();
-   *
    *  }
    *
    *  function draw() {
@@ -179,11 +180,14 @@ define(function () {
    *  var cnv, soundFile, fft, peakDetect;
    *  var ellipseWidth = 0;
    *
+   *  function preload() {
+   *    soundFile = loadSound('assets/beat.mp3');
+   *  }
+   *
    *  function setup() {
    *    cnv = createCanvas(100,100);
    *    textAlign(CENTER);
    *
-   *    soundFile = loadSound('assets/beat.mp3');
    *    fft = new p5.FFT();
    *    peakDetect = new p5.PeakDetect();
    *

--- a/src/reverb.js
+++ b/src/reverb.js
@@ -316,7 +316,13 @@ define(function (require) {
     if (window.location.origin.indexOf('file://') > -1 && window.cordova === 'undefined') {
       alert('This sketch may require a server to load external files. Please see http://bit.ly/1qcInwS');
     }
-    var cReverb = new p5.Convolver(path, callback, errorCallback);
+    var self = this;
+    var cReverb = new p5.Convolver(path, function(buffer) {
+      if (typeof callback === 'function') {
+        callback(buffer);
+      }
+      self._decrementPreload();
+    }, errorCallback);
     cReverb.impulses = [];
     return cReverb;
   };

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -451,7 +451,8 @@ define(function (require) {
    *  @param  {String} str 'restart' or 'sustain' or 'untilDone'
    *  @example
    *  <div><code>
-   *  function setup(){
+   *  var mySound;
+   *  function preload(){
    *    mySound = loadSound('assets/Damscray_DancingTiger.mp3');
    *  }
    *  function mouseClicked() {
@@ -734,7 +735,7 @@ define(function (require) {
    *  var ball = {};
    *  var soundFile;
    *
-   *  function setup() {
+   *  function preload() {
    *    soundFormats('ogg', 'mp3');
    *    soundFile = loadSound('assets/beatbox.mp3');
    *  }
@@ -1521,14 +1522,17 @@ define(function (require) {
    *                      useful for removeCue(id)
    *  @example
    *  <div><code>
+   *  var mySound;
+   *  function preload() {
+   *    mySound = loadSound('assets/beat.mp3');
+   *  }
+   *
    *  function setup() {
    *    background(0);
    *    noStroke();
    *    fill(255);
    *    textAlign(CENTER);
    *    text('click to play', width/2, height/2);
-   *
-   *    mySound = loadSound('assets/beat.mp3');
    *
    *    // schedule calls to changeText
    *    mySound.addCue(0.50, changeText, "hello" );


### PR DESCRIPTION
this PR fixes a few issues found when running the p5.js reference tests in browser:
- ensures `loadSound()` is called from `preload`. this prevents the p5 instance from being removed before the load has completed which can cause issues especially during the tests when multiple p5 instances are created one after the other.
- ensures that `createConvolver()` calls `_decrementPreload`. this allows preload functions that create convolvers to complete.
- fixes some asset paths.