### PR TITLE
protect against errors during duplicate dispose/disconnect calls

### DIFF
--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -166,7 +166,9 @@ define(function (require) {
   };
 
   p5.Amplitude.prototype.disconnect = function() {
-    this.output.disconnect();
+    if (this.output) {
+      this.output.disconnect();
+    }
   };
 
   // TO DO make this stereo / dependent on # of audio channels
@@ -305,11 +307,16 @@ define(function (require) {
     var index = p5sound.soundArray.indexOf(this);
     p5sound.soundArray.splice(index, 1);
 
-    this.input.disconnect();
-    this.output.disconnect();
+    if (this.input) {
+      this.input.disconnect();
+      delete this.input;
+    }
+    if (this.output) {
+      this.output.disconnect();
+      delete this.output;
+    }
 
-    this.input = this.processor = undefined;
-    this.output = undefined;
+    delete this.processor;
   };
 
 });

--- a/src/audioVoice.js
+++ b/src/audioVoice.js
@@ -65,8 +65,10 @@ define(function() {
   };
 
   p5.AudioVoice.prototype.dispose = function() {
-    this.output.disconnect();
-    delete this.output;
+    if (this.output) {
+      this.output.disconnect();
+      delete this.output;
+    }
   };
 
   return p5.AudioVoice;

--- a/src/audioin.js
+++ b/src/audioin.js
@@ -179,9 +179,11 @@ define(function (require) {
    *  @method  disconnect
    */
   p5.AudioIn.prototype.disconnect = function() {
-    this.output.disconnect();
-    // stay connected to amplitude even if not outputting to p5
-    this.output.connect(this.amplitude.input);
+    if (this.output) {
+      this.output.disconnect();
+      // stay connected to amplitude even if not outputting to p5
+      this.output.connect(this.amplitude.input);
+    }
   };
 
   /**

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -215,9 +215,11 @@ define(function (require) {
 
 
 	p5.Compressor.prototype.dispose = function() {
-		Effect.prototype.dispose.apply(this);
-		this.compressor.disconnect();
-		this.compressor = undefined;
+    Effect.prototype.dispose.apply(this);
+    if (this.compressor) {
+      this.compressor.disconnect();
+      delete this.compressor;
+    }
 	};
 
   return p5.Compressor;

--- a/src/distortion.js
+++ b/src/distortion.js
@@ -132,7 +132,9 @@ define(function (require) {
 
   p5.Distortion.prototype.dispose = function() {
     Effect.prototype.dispose.apply(this);
-    this.waveShaperNode.disconnect();
-    this.waveShaperNode = null;
+    if (this.waveShaperNode) {
+      this.waveShaperNode.disconnect();
+      this.waveShaperNode = null;
+    }
   };
 });

--- a/src/effect.js
+++ b/src/effect.js
@@ -1,153 +1,163 @@
 'use strict';
 define(function (require) {
 
-	var p5sound = require('master');
-	var CrossFade = require('Tone/component/CrossFade');
+  var p5sound = require('master');
+  var CrossFade = require('Tone/component/CrossFade');
 
-	/**
-	 * Effect is a base class for audio effects in p5. <br>
-	 * This module handles the nodes and methods that are 
-	 * common and useful for current and future effects.
-	 *
-	 *
-	 * This class is extended by <a href="/reference/#/p5.Distortion">p5.Distortion</a>, 
-	 * <a href="/reference/#/p5.Compressor">p5.Compressor</a>,
-	 * <a href="/reference/#/p5.Delay">p5.Delay</a>, 
-	 * <a href="/reference/#/p5.Filter">p5.Filter</a>, 
-	 * <a href="/reference/#/p5.Reverb">p5.Reverb</a>.
-	 *
-	 * @class  p5.Effect
-	 * @constructor
-	 * 
-	 * @param {Object} [ac]   Reference to the audio context of the p5 object
-	 * @param {AudioNode} [input]  Gain Node effect wrapper
-	 * @param {AudioNode} [output] Gain Node effect wrapper
-	 * @param {Object} [_drywet]   Tone.JS CrossFade node (defaults to value: 1)
-	 * @param {AudioNode} [wet]  Effects that extend this class should connect
-	 *                              to the wet signal to this gain node, so that dry and wet 
-	 *                              signals are mixed properly.
-	 */
-	p5.Effect = function() {
-		this.ac = p5sound.audiocontext;
+  /**
+   * Effect is a base class for audio effects in p5. <br>
+   * This module handles the nodes and methods that are 
+   * common and useful for current and future effects.
+   *
+   *
+   * This class is extended by <a href="/reference/#/p5.Distortion">p5.Distortion</a>, 
+   * <a href="/reference/#/p5.Compressor">p5.Compressor</a>,
+   * <a href="/reference/#/p5.Delay">p5.Delay</a>, 
+   * <a href="/reference/#/p5.Filter">p5.Filter</a>, 
+   * <a href="/reference/#/p5.Reverb">p5.Reverb</a>.
+   *
+   * @class  p5.Effect
+   * @constructor
+   * 
+   * @param {Object} [ac]   Reference to the audio context of the p5 object
+   * @param {AudioNode} [input]  Gain Node effect wrapper
+   * @param {AudioNode} [output] Gain Node effect wrapper
+   * @param {Object} [_drywet]   Tone.JS CrossFade node (defaults to value: 1)
+   * @param {AudioNode} [wet]  Effects that extend this class should connect
+   *                              to the wet signal to this gain node, so that dry and wet 
+   *                              signals are mixed properly.
+   */
+  p5.Effect = function() {
+    this.ac = p5sound.audiocontext;
 
-		this.input = this.ac.createGain();
-		this.output = this.ac.createGain();
+    this.input = this.ac.createGain();
+    this.output = this.ac.createGain();
 
-		 /**
-		  *	The p5.Effect class is built
-		  * 	using Tone.js CrossFade
-		  * 	@private
-		  */
-		 
-		this._drywet = new CrossFade(1);
+     /**
+      *	The p5.Effect class is built
+      * 	using Tone.js CrossFade
+      * 	@private
+      */
+     
+    this._drywet = new CrossFade(1);
 
-		/**
-		 *	In classes that extend
-		 *	p5.Effect, connect effect nodes
-		 *	to the wet parameter
-		 */
-		this.wet = this.ac.createGain();
+    /**
+     *	In classes that extend
+     *	p5.Effect, connect effect nodes
+     *	to the wet parameter
+     */
+    this.wet = this.ac.createGain();
 
-		this.input.connect(this._drywet.a);
-		this.wet.connect(this._drywet.b);
-		this._drywet.connect(this.output);
+    this.input.connect(this._drywet.a);
+    this.wet.connect(this._drywet.b);
+    this._drywet.connect(this.output);
 
-		this.connect();
+    this.connect();
 
-		//Add to the soundArray
-		p5sound.soundArray.push(this);
-	};
+    //Add to the soundArray
+    p5sound.soundArray.push(this);
+  };
 
-	/**
-	 *  Set the output volume of the filter.
-	 *  
-	 *  @method  amp
-	 *  @param {Number} [vol] amplitude between 0 and 1.0
-	 *  @param {Number} [rampTime] create a fade that lasts until rampTime 
-	 *  @param {Number} [tFromNow] schedule this event to happen in tFromNow seconds
-	 */
-	p5.Effect.prototype.amp = function(vol, rampTime, tFromNow){
-	  var rampTime = rampTime || 0;
-	  var tFromNow = tFromNow || 0;
-	  var now = p5sound.audiocontext.currentTime;
-	  var currentVol = this.output.gain.value;
-	  this.output.gain.cancelScheduledValues(now);
-	  this.output.gain.linearRampToValueAtTime(currentVol, now + tFromNow + .001);
-	  this.output.gain.linearRampToValueAtTime(vol, now + tFromNow + rampTime + .001);
-	};
+  /**
+   *  Set the output volume of the filter.
+   *  
+   *  @method  amp
+   *  @param {Number} [vol] amplitude between 0 and 1.0
+   *  @param {Number} [rampTime] create a fade that lasts until rampTime 
+   *  @param {Number} [tFromNow] schedule this event to happen in tFromNow seconds
+   */
+  p5.Effect.prototype.amp = function(vol, rampTime, tFromNow){
+    var rampTime = rampTime || 0;
+    var tFromNow = tFromNow || 0;
+    var now = p5sound.audiocontext.currentTime;
+    var currentVol = this.output.gain.value;
+    this.output.gain.cancelScheduledValues(now);
+    this.output.gain.linearRampToValueAtTime(currentVol, now + tFromNow + .001);
+    this.output.gain.linearRampToValueAtTime(vol, now + tFromNow + rampTime + .001);
+  };
 
-	/**
-	 *	Link effects together in a chain	
-	 *	Example usage: filter.chain(reverb, delay, panner);
-	 *	May be used with an open-ended number of arguments
-	 *
-	 *	@method chain 
+  /**
+   *	Link effects together in a chain	
+   *	Example usage: filter.chain(reverb, delay, panner);
+   *	May be used with an open-ended number of arguments
+   *
+   *	@method chain 
      *  @param {Object} [arguments]  Chain together multiple sound objects	
-	 */		
-	p5.Effect.prototype.chain = function(){
-		if (arguments.length>0){
-			this.connect(arguments[0]);
-			for(var i=1;i<arguments.length; i+=1){
-				arguments[i-1].connect(arguments[i]);
-			}
-		}
-		return this;
-	};
+   */		
+  p5.Effect.prototype.chain = function(){
+    if (arguments.length>0){
+      this.connect(arguments[0]);
+      for(var i=1;i<arguments.length; i+=1){
+        arguments[i-1].connect(arguments[i]);
+      }
+    }
+    return this;
+  };
 
-	/**
-	 *	Adjust the dry/wet value.	
-	 *	
-	 *	@method drywet
-	 *	@param {Number} [fade] The desired drywet value (0 - 1.0)
-	 */
-	p5.Effect.prototype.drywet = function(fade){
-		if (typeof fade !=="undefined"){	
-			this._drywet.fade.value = fade
-		}
-		return this._drywet.fade.value;
-	};
+  /**
+   *	Adjust the dry/wet value.	
+   *	
+   *	@method drywet
+   *	@param {Number} [fade] The desired drywet value (0 - 1.0)
+   */
+  p5.Effect.prototype.drywet = function(fade){
+    if (typeof fade !=="undefined"){	
+      this._drywet.fade.value = fade
+    }
+    return this._drywet.fade.value;
+  };
 
-	/**
-	 *	Send output to a p5.js-sound, Web Audio Node, or use signal to
-	 *	control an AudioParam	
-	 *	
-	 *	@method connect 
-	 *	@param {Object} unit 
-	 */
-	p5.Effect.prototype.connect = function (unit) {
-		var u = unit || p5.soundOut.input;
-		this.output.connect(u.input ? u.input : u);
-	};
+  /**
+   *	Send output to a p5.js-sound, Web Audio Node, or use signal to
+   *	control an AudioParam	
+   *	
+   *	@method connect 
+   *	@param {Object} unit 
+   */
+  p5.Effect.prototype.connect = function (unit) {
+    var u = unit || p5.soundOut.input;
+    this.output.connect(u.input ? u.input : u);
+  };
 
-	/**
-	 *	Disconnect all output.	
-	 *	
-	 *	@method disconnect 
-	 */
-	p5.Effect.prototype.disconnect = function() {
-		this.output.disconnect();
-	};
+  /**
+   *	Disconnect all output.	
+   *	
+   *	@method disconnect 
+   */
+  p5.Effect.prototype.disconnect = function() {
+    if (this.output) {
+      this.output.disconnect();
+    }
+  };
 
-	p5.Effect.prototype.dispose = function() {
-		// remove refernce form soundArray
-		var index = p5sound.soundArray.indexOf(this);
-		p5sound.soundArray.splice(index, 1);
+  p5.Effect.prototype.dispose = function() {
+    // remove refernce form soundArray
+    var index = p5sound.soundArray.indexOf(this);
+    p5sound.soundArray.splice(index, 1);
 
-		this.input.disconnect();
-		this.input = undefined;
+    if (this.input) {
+      this.input.disconnect();
+      delete this.input;
+    }
 
-		this.output.disconnect();
-		this.output = undefined;
+    if (this.output) {
+      this.output.disconnect();
+      delete this.output;
+    }
 
-    this._drywet.disconnect();
-    delete this._drywet;
+    if (this._drywet) {
+      this._drywet.disconnect();
+      delete this._drywet;
+    }
 
-    this.wet.disconnect();
-    delete this.wet;
+    if (this.wet) {
+      this.wet.disconnect();
+      delete this.wet;
+    }
 
-		this.ac = undefined;
-	};
+    this.ac = undefined;
+  };
 
-	return p5.Effect;
+  return p5.Effect;
 
 });

--- a/src/env.js
+++ b/src/env.js
@@ -823,7 +823,9 @@ define(function (require) {
   };
 
   p5.Env.prototype.disconnect = function() {
-    this.output.disconnect();
+    if (this.output) {
+      this.output.disconnect();
+    }
   };
 
 
@@ -891,11 +893,9 @@ define(function (require) {
     p5sound.soundArray.splice(index, 1);
 
     this.disconnect();
-    try{
+    if (this.control) {
       this.control.dispose();
       this.control = null;
-    } catch(e) {
-      console.warn(e, 'already disposed p5.Env');
     }
     for (var i = 1; i < this.mathOps.length; i++) {
       this.mathOps[i].dispose();

--- a/src/eq.js
+++ b/src/eq.js
@@ -197,10 +197,12 @@ define(function (require) {
   p5.EQ.prototype.dispose = function () {
     Effect.prototype.dispose.apply(this);
 
-    while (this.bands.length > 0) {
-      delete this.bands.pop().dispose();
+    if (this.bands) {
+      while (this.bands.length > 0) {
+        delete this.bands.pop().dispose();
+      }
+      delete this.bands;
     }
-    delete this.bands;
   };
 
   return p5.EQ;

--- a/src/eqFilter.js
+++ b/src/eqFilter.js
@@ -39,7 +39,9 @@ define(function (require) {
   };
 
   EQFilter.prototype.disconnect = function() {
-    this.biquad.disconnect();
+    if (this.biquad) {
+      this.biquad.disconnect();
+    }
   };
   EQFilter.prototype.dispose = function() {
     // remove reference form soundArray

--- a/src/fft.js
+++ b/src/fft.js
@@ -489,8 +489,10 @@ define(function(require) {
     var index = p5sound.soundArray.indexOf(this);
     p5sound.soundArray.splice(index, 1);
 
-    this.analyser.disconnect();
-    this.analyser = undefined;
+    if (this.analyser) {
+      this.analyser.disconnect();
+      delete this.analyser;
+    }
   };
 
   /**

--- a/src/filter.js
+++ b/src/filter.js
@@ -252,8 +252,10 @@ define(function (require) {
   p5.Filter.prototype.dispose = function() {
     // remove reference from soundArray
     Effect.prototype.dispose.apply(this);
-    this.biquad.disconnect();
-    this.biquad = undefined;
+    if (this.biquad) {
+      this.biquad.disconnect();
+      delete this.biquad;
+    }
   };
 
   /**

--- a/src/gain.js
+++ b/src/gain.js
@@ -114,7 +114,9 @@ define(function (require) {
    *  @method disconnect
    */
   p5.Gain.prototype.disconnect = function() {
-    this.output.disconnect();
+    if (this.output) {
+      this.output.disconnect();
+    }
   };
 
   /**
@@ -140,10 +142,14 @@ define(function (require) {
     // remove reference from soundArray
     var index = p5sound.soundArray.indexOf(this);
     p5sound.soundArray.splice(index, 1);
-    this.output.disconnect();
-    this.input.disconnect();
-    this.output = undefined;
-    this.input = undefined;
+    if (this.output) {
+      this.output.disconnect();
+      delete this.output;
+    }
+    if (this.input) {
+      this.input.disconnect();
+      delete this.input;
+    }
   };
 
 });

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -240,7 +240,9 @@ define(function (require) {
    *  @method  disconnect
    */
   p5.MonoSynth.prototype.disconnect = function() {
-    this.output.disconnect();
+    if (this.output) {
+      this.output.disconnect();
+    }
   };
 
 
@@ -252,12 +254,14 @@ define(function (require) {
   p5.MonoSynth.prototype.dispose = function() {
     AudioVoice.prototype.dispose.apply(this);
 
-    this.filter.dispose();
-    this.env.dispose();
-    try {
+    if (this.filter) {
+      this.filter.dispose();
+    }
+    if (this.env) {
+      this.env.dispose();
+    }
+    if (this.oscillator) {
       this.oscillator.dispose();
-    } catch(e) {
-      console.error('mono synth default oscillator already disposed');
     }
   };
 

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -128,7 +128,7 @@ define(function (require) {
       // set old osc free to be garbage collected (memory)
       if (this.oscillator) {
         this.oscillator.disconnect();
-        this.oscillator = undefined;
+        delete this.oscillator;
       }
 
       // var detune = this.oscillator.frequency.value;
@@ -314,9 +314,15 @@ define(function (require) {
    *  @method  disconnect
    */
   p5.Oscillator.prototype.disconnect = function() {
-    this.output.disconnect();
-    this.panner.disconnect();
-    this.output.connect(this.panner);
+    if (this.output) {
+      this.output.disconnect();
+    }
+    if (this.panner) {
+      this.panner.disconnect();
+      if (this.output) {
+        this.output.connect(this.panner);
+      }
+    }
     this.oscMods = [];
   };
 

--- a/src/panner.js
+++ b/src/panner.js
@@ -32,7 +32,9 @@ define(function (require) {
     };
 
     p5.Panner.prototype.disconnect = function() {
-      this.stereoPanner.disconnect();
+      if (this.stereoPanner) {
+        this.stereoPanner.disconnect();
+      }
     };
 
   } else {
@@ -99,7 +101,9 @@ define(function (require) {
     };
 
     p5.Panner.prototype.disconnect = function() {
-      this.output.disconnect();
+      if (this.output) {
+        this.output.disconnect();
+      }
     };
   }
 });

--- a/src/panner3d.js
+++ b/src/panner3d.js
@@ -230,8 +230,10 @@ define(function (require) {
 
   p5.Panner3D.dispose = function() {
     Effect.prototype.dispose.apply(this);
-    this.panner.disconnect();
-    delete this.panner;
+    if (this.panner) {
+      this.panner.disconnect();
+      delete this.panner;
+    }
   };
 
   return p5.Panner3D;

--- a/src/polysynth.js
+++ b/src/polysynth.js
@@ -320,7 +320,9 @@ define(function (require) {
   *  @method  disconnect
   */
   p5.PolySynth.prototype.disconnect = function() {
-    this.output.disconnect();
+    if (this.output) {
+      this.output.disconnect();
+    }
   };
 
   /**
@@ -333,8 +335,10 @@ define(function (require) {
       voice.dispose();
     });
 
-    this.output.disconnect();
-    delete this.output;
+    if (this.output) {
+      this.output.disconnect();
+      delete this.output;
+    }
   };
 
 });

--- a/src/pulse.js
+++ b/src/pulse.js
@@ -146,7 +146,9 @@ define(function (require) {
       var t = time || 0;
       var now = p5sound.audiocontext.currentTime;
       this.oscillator.stop(t + now);
-      this.osc2.oscillator.stop(t + now);
+      if (this.osc2.oscillator) {
+        this.osc2.oscillator.stop(t + now);
+      }
       this.dcOffset.stop(t + now);
       this.started = false;
       this.osc2.started = false;

--- a/src/reverb.js
+++ b/src/reverb.js
@@ -529,8 +529,10 @@ define(function (require) {
       }
     }
 
-    this.convolverNode.disconnect();
-    this.concolverNode = null;
+    if (this.convolverNode) {
+      this.convolverNode.disconnect();
+      this.concolverNode = null;
+    }
   };
 
 });

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -328,6 +328,11 @@ define(function (require) {
    * @param {Number} [duration]          (optional) duration of playback in seconds
    */
   p5.SoundFile.prototype.play = function(startTime, rate, amp, _cueStart, duration) {
+    if (!this.output) {
+      console.warn('SoundFile.play() called after dispose');
+      return;
+    }
+
     var self = this;
     var now = p5sound.audiocontext.currentTime;
     var cueStart, cueEnd;
@@ -1132,7 +1137,9 @@ define(function (require) {
    * @method disconnect
    */
   p5.SoundFile.prototype.disconnect = function() {
-    this.panner.disconnect();
+    if (this.panner) {
+      this.panner.disconnect();
+    }
   };
 
   /**


### PR DESCRIPTION
i have added some extra protection around the dispose/disconnect calls. in normal use these errors don't usually occur, but in the context of the p5 tests where many p5 instances are continuously brought up and torn down, sometimes these trigger.

this is in order to get the p5.js tests to all pass. specifically, we're investigating using headless-chrome instead of phantomjs which allows the webl & sound tests to run as part of the regular travis build-validation pass.