### PR TITLE
Fix effect class extension reference urls

### DIFF
--- a/src/effect.js
+++ b/src/effect.js
@@ -6,25 +6,25 @@ define(function (require) {
 
 	/**
 	 * Effect is a base class for audio effects in p5. <br>
-	 * This module handles the nodes and methods that are 
+	 * This module handles the nodes and methods that are
 	 * common and useful for current and future effects.
 	 *
 	 *
-	 * This class is extended by <a href="/reference/#/p5.Distortion">p5.Distortion</a>, 
-	 * <a href="/reference/#/p5.Compressor">p5.Compressor</a>,
-	 * <a href="/reference/#/p5.Delay">p5.Delay</a>, 
-	 * <a href="/reference/#/p5.Filter">p5.Filter</a>, 
-	 * <a href="/reference/#/p5.Reverb">p5.Reverb</a>.
+	 * This class is extended by <a href="#/p5.Distortion">p5.Distortion</a>,
+	 * <a href="#/p5.Compressor">p5.Compressor</a>,
+	 * <a href="#/p5.Delay">p5.Delay</a>,
+	 * <a href="#/p5.Filter">p5.Filter</a>,
+	 * <a href="#/p5.Reverb">p5.Reverb</a>.
 	 *
 	 * @class  p5.Effect
 	 * @constructor
-	 * 
+	 *
 	 * @param {Object} [ac]   Reference to the audio context of the p5 object
 	 * @param {AudioNode} [input]  Gain Node effect wrapper
 	 * @param {AudioNode} [output] Gain Node effect wrapper
 	 * @param {Object} [_drywet]   Tone.JS CrossFade node (defaults to value: 1)
 	 * @param {AudioNode} [wet]  Effects that extend this class should connect
-	 *                              to the wet signal to this gain node, so that dry and wet 
+	 *                              to the wet signal to this gain node, so that dry and wet
 	 *                              signals are mixed properly.
 	 */
 	p5.Effect = function() {
@@ -38,7 +38,7 @@ define(function (require) {
 		  * 	using Tone.js CrossFade
 		  * 	@private
 		  */
-		 
+
 		this._drywet = new CrossFade(1);
 
 		/**
@@ -60,10 +60,10 @@ define(function (require) {
 
 	/**
 	 *  Set the output volume of the filter.
-	 *  
+	 *
 	 *  @method  amp
 	 *  @param {Number} [vol] amplitude between 0 and 1.0
-	 *  @param {Number} [rampTime] create a fade that lasts until rampTime 
+	 *  @param {Number} [rampTime] create a fade that lasts until rampTime
 	 *  @param {Number} [tFromNow] schedule this event to happen in tFromNow seconds
 	 */
 	p5.Effect.prototype.amp = function(vol, rampTime, tFromNow){
@@ -77,13 +77,13 @@ define(function (require) {
 	};
 
 	/**
-	 *	Link effects together in a chain	
+	 *	Link effects together in a chain
 	 *	Example usage: filter.chain(reverb, delay, panner);
 	 *	May be used with an open-ended number of arguments
 	 *
-	 *	@method chain 
-     *  @param {Object} [arguments]  Chain together multiple sound objects	
-	 */		
+	 *	@method chain
+     *  @param {Object} [arguments]  Chain together multiple sound objects
+	 */
 	p5.Effect.prototype.chain = function(){
 		if (arguments.length>0){
 			this.connect(arguments[0]);
@@ -95,13 +95,13 @@ define(function (require) {
 	};
 
 	/**
-	 *	Adjust the dry/wet value.	
-	 *	
+	 *	Adjust the dry/wet value.
+	 *
 	 *	@method drywet
 	 *	@param {Number} [fade] The desired drywet value (0 - 1.0)
 	 */
 	p5.Effect.prototype.drywet = function(fade){
-		if (typeof fade !=="undefined"){	
+		if (typeof fade !=="undefined"){
 			this._drywet.fade.value = fade
 		}
 		return this._drywet.fade.value;
@@ -109,10 +109,10 @@ define(function (require) {
 
 	/**
 	 *	Send output to a p5.js-sound, Web Audio Node, or use signal to
-	 *	control an AudioParam	
-	 *	
-	 *	@method connect 
-	 *	@param {Object} unit 
+	 *	control an AudioParam
+	 *
+	 *	@method connect
+	 *	@param {Object} unit
 	 */
 	p5.Effect.prototype.connect = function (unit) {
 		var u = unit || p5.soundOut.input;
@@ -120,9 +120,9 @@ define(function (require) {
 	};
 
 	/**
-	 *	Disconnect all output.	
-	 *	
-	 *	@method disconnect 
+	 *	Disconnect all output.
+	 *
+	 *	@method disconnect
 	 */
 	p5.Effect.prototype.disconnect = function() {
 		this.output.disconnect();


### PR DESCRIPTION
This PR updates the class extension reference urls in p5 Effect as they are currently 404-ing, as well as some minor whitespace corrections.