### PR TITLE
monoSynth and polySynth fixes + examples

### DIFF
--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -5,8 +5,8 @@ define(function (require) {
   var AudioVoice = require('audioVoice');
 
   /**
-    *  An MonoSynth is used as a single voice for sound synthesis.
-    *  This is a class to be used in conjonction with the PolySynth
+    *  A MonoSynth is used as a single voice for sound synthesis.
+    *  This is a class to be used in conjunction with the PolySynth
     *  class. Custom synthetisers should be built inheriting from
     *  this class.
     *
@@ -14,16 +14,31 @@ define(function (require) {
     *  @constructor
     *  @example
     *  <div><code>
-    *  var monosynth;
-    *  var x;
+    *  var monoSynth;
     *
     *  function setup() {
-    *    monosynth = new p5.MonoSynth();
-    *    monosynth.play(45,1,x=0,1);
-    *    monosynth.play(49,1,x+=1,0.25);
-    *    monosynth.play(50,1,x+=0.25,0.25);
-    *    monosynth.play(49,1,x+=0.5,0.25);
-    *    monosynth.play(50,1,x+=0.25,0.25);
+    *    var cnv = createCanvas(100, 100);
+    *    cnv.mousePressed(playSynth);
+    *
+    *    monoSynth = new p5.MonoSynth();
+    *
+    *    textAlign(CENTER);
+    *    text('click to play', width/2, height/2);
+    *  }
+    *
+    *  function playSynth() {
+    *    // time from now (in seconds)
+    *    var time = 0;
+    *    // note duration (in seconds)
+    *    var dur = 0.25;
+    *    // velocity (volume, from 0 to 1)
+    *    var v = 0.2;
+    *
+    *    monoSynth.play("G3", v, time, dur);
+    *    monoSynth.play("C4", v, time += dur, dur);
+    *
+    *    background(random(255), random(255), 255);
+    *    text('click to play', width/2, height/2);
     *  }
     *  </code></div>
     **/
@@ -66,20 +81,49 @@ define(function (require) {
   p5.MonoSynth.prototype = Object.create(p5.AudioVoice.prototype);
 
   /**
-     *  Play tells the MonoSynth to start playing a note. This method schedules
-     *  the calling of .triggerAttack and .triggerRelease.
-     *
-     *  @method play
-     *  @param {String | Number} note the note you want to play, specified as a 
-     *                                 frequency in Hertz (Number) or as a midi 
-     *                                 value in Note/Octave format ("C4", "Eb3"...etc")
-     *                                 See <a href = "https://github.com/Tonejs/Tone.js/wiki/Instruments">
-     *                                 Tone</a>. Defaults to 440 hz.
-     *  @param  {Number} [velocity] velocity of the note to play (ranging from 0 to 1)
-     *  @param  {Number} [secondsFromNow]  time from now (in seconds) at which to play
-     *  @param  {Number} [sustainTime] time to sustain before releasing the envelope
-     *
-     */
+    *  Play tells the MonoSynth to start playing a note. This method schedules
+    *  the calling of .triggerAttack and .triggerRelease.
+    *
+    *  @method play
+    *  @param {String | Number} note the note you want to play, specified as a
+    *                                 frequency in Hertz (Number) or as a midi
+    *                                 value in Note/Octave format ("C4", "Eb3"...etc")
+    *                                 See <a href = "https://github.com/Tonejs/Tone.js/wiki/Instruments">
+    *                                 Tone</a>. Defaults to 440 hz.
+    *  @param  {Number} [velocity] velocity of the note to play (ranging from 0 to 1)
+    *  @param  {Number} [secondsFromNow]  time from now (in seconds) at which to play
+    *  @param  {Number} [sustainTime] time to sustain before releasing the envelope
+    *  @example
+    *  <div><code>
+    *  var monoSynth;
+    *
+    *  function setup() {
+    *    var cnv = createCanvas(100, 100);
+    *    cnv.mousePressed(playSynth);
+    *
+    *    monoSynth = new p5.MonoSynth();
+    *
+    *    textAlign(CENTER);
+    *    text('click to play', width/2, height/2);
+    *  }
+    *
+    *  function playSynth() {
+    *    // time from now (in seconds)
+    *    var time = 0;
+    *    // note duration (in seconds)
+    *    var dur = 1/6;
+    *    // note velocity (volume, from 0 to 1)
+    *    var v = random();
+    *
+    *    monoSynth.play("Fb3", v, 0, dur);
+    *    monoSynth.play("Gb3", v, time += dur, dur);
+    *
+    *    background(random(255), random(255), 255);
+    *    text('click to play', width/2, height/2);
+    *  }
+    *  </code></div>
+    *
+    */
   p5.MonoSynth.prototype.play = function (note, velocity, secondsFromNow, susTime) {
     // set range of env (TO DO: allow this to be scheduled in advance)
     var susTime = susTime || this.sustain;
@@ -93,14 +137,26 @@ define(function (require) {
      *  Similar to holding down a key on a piano, but it will
      *  hold the sustain level until you let go.
      *
-     *  @param {String | Number} note the note you want to play, specified as a 
-     *                                 frequency in Hertz (Number) or as a midi 
+     *  @param {String | Number} note the note you want to play, specified as a
+     *                                 frequency in Hertz (Number) or as a midi
      *                                 value in Note/Octave format ("C4", "Eb3"...etc")
      *                                 See <a href = "https://github.com/Tonejs/Tone.js/wiki/Instruments">
      *                                 Tone</a>. Defaults to 440 hz
      *  @param  {Number} [velocity] velocity of the note to play (ranging from 0 to 1)
      *  @param  {Number} [secondsFromNow]  time from now (in seconds) at which to play
      *  @method  triggerAttack
+     *  @example
+     *  <div><code>
+     *  var monoSynth = new p5.MonoSynth();
+     *
+     *  function mousePressed() {
+     *    monoSynth.triggerAttack("E3");
+     *  }
+     *
+     *  function mouseReleased() {
+     *    monoSynth.triggerRelease();
+     *  }
+     *  </code></div>
      */
   p5.MonoSynth.prototype.triggerAttack = function (note, velocity, secondsFromNow) {
     var secondsFromNow = secondsFromNow || 0;
@@ -121,6 +177,18 @@ define(function (require) {
      *
      *  @param  {Number} secondsFromNow time to trigger the release
      *  @method  triggerRelease
+     *  @example
+     *  <div><code>
+     *  var monoSynth = new p5.MonoSynth();
+     *
+     *  function mousePressed() {
+     *    monoSynth.triggerAttack("E3");
+     *  }
+     *
+     *  function mouseReleased() {
+     *    monoSynth.triggerRelease();
+     *  }
+     *  </code></div>
      */
   p5.MonoSynth.prototype.triggerRelease = function (secondsFromNow) {
     var secondsFromNow = secondsFromNow || 0;

--- a/src/polysynth.js
+++ b/src/polysynth.js
@@ -6,18 +6,19 @@ define(function (require) {
   var TimelineSignal = require('Tone/signal/TimelineSignal');
   require('sndcore');
 
+
   /**
     *  An AudioVoice is used as a single voice for sound synthesis.
     *  The PolySynth class holds an array of AudioVoice, and deals
     *  with voices allocations, with setting notes to be played, and
-    *  parameters to be set. 
+    *  parameters to be set.
     *
     *  @class p5.PolySynth
     *  @constructor
-    *  
+    *
     *  @param {Number} [synthVoice]   A monophonic synth voice inheriting
     *                                 the AudioVoice class. Defaults to p5.MonoSynth
-    *  @param {Number} [polyValue] Number of voices, defaults to 8;
+    *  @param {Number} [maxVoices] Number of voices, defaults to 8;
     *
     *
     *  @example
@@ -32,19 +33,19 @@ define(function (require) {
     *    polysynth.play(74,1,0,3);
     *  }
     *  </code></div>
-    *  
+    *
     **/
-  p5.PolySynth = function(audioVoice, polyValue) {
-    //audiovoices will contain polyValue many monophonic synths
+  p5.PolySynth = function(audioVoice, maxVoices) {
+    //audiovoices will contain maxVoices many monophonic synths
     this.audiovoices = [];
 
     /**
-     * An object that holds information about which notes have been played and 
+     * An object that holds information about which notes have been played and
      * which notes are currently being played. New notes are added as keys
      * on the fly. While a note has been attacked, but not released, the value of the
      * key is the audiovoice which is generating that note. When notes are released,
-     * the value of the key becomes undefined. 
-     * @property notes 
+     * the value of the key becomes undefined.
+     * @property notes
      */
     this.notes = {};
 
@@ -56,7 +57,7 @@ define(function (require) {
      * A PolySynth must have at least 1 voice, defaults to 8
      * @property polyvalue
      */
-    this.polyValue = polyValue || 8;
+    this.maxVoices = maxVoices || 8;
 
     /**
      * Monosynth that generates the sound for each note that is triggered. The
@@ -87,7 +88,7 @@ define(function (require) {
    * @method  _allocateVoices
    */
   p5.PolySynth.prototype._allocateVoices = function() {
-    for(var i = 0; i< this.polyValue; i++) {
+    for(var i = 0; i< this.maxVoices; i++) {
       this.audiovoices.push(new this.AudioVoice());
       this.audiovoices[i].disconnect();
       this.audiovoices[i].connect(this.output);
@@ -96,7 +97,7 @@ define(function (require) {
 
   /**
    *  Play a note by triggering noteAttack and noteRelease with sustain time
-   *  
+   *
    *  @method  play
    *  @param  {Number} [note] midi note to play (ranging from 0 to 127 - 60 being a middle C)
    *  @param  {Number} [velocity] velocity of the note to play (ranging from 0 to 1)
@@ -110,12 +111,12 @@ define(function (require) {
   };
 
 
-  /** 
+  /**
    *  noteADSR sets the envelope for a specific note that has just been triggered.
    *  Using this method modifies the envelope of whichever audiovoice is being used
    *  to play the desired note. The envelope should be reset before noteRelease is called
    *  in order to prevent the modified envelope from being used on other notes.
-   *  
+   *
    *  @method  noteADSR
    *  @param {Number} [note]        Midi note on which ADSR should be set.
    *  @param {Number} [attackTime]  Time (in seconds before envelope
@@ -141,10 +142,10 @@ define(function (require) {
   };
 
 
-  /** 
+  /**
    * Set the PolySynths global envelope. This method modifies the envelopes of each
    * monosynth so that all notes are played with this envelope.
-   *  
+   *
    *  @method  setADSR
    *  @param {Number} [note]        Midi note on which ADSR should be set.
    *  @param {Number} [attackTime]  Time (in seconds before envelope
@@ -170,14 +171,14 @@ define(function (require) {
   /**
    *  Trigger the Attack, and Decay portion of a MonoSynth.
    *  Similar to holding down a key on a piano, but it will
-   *  hold the sustain level until you let go. 
+   *  hold the sustain level until you let go.
    *
    *  @method  noteAttack
    *  @param  {Number} [note]           midi note on which attack should be triggered.
    *  @param  {Number} [velocity]       velocity of the note to play (ranging from 0 to 1)/
    *  @param  {Number} [secondsFromNow] time from now (in seconds)
-   *  
-   */  
+   *
+   */
   p5.PolySynth.prototype.noteAttack = function (_note, _velocity, secondsFromNow) {
     var now =  p5sound.audiocontext.currentTime;
 
@@ -201,8 +202,8 @@ define(function (require) {
     }
 
     //Check to see how many voices are in use at the time the note will start
-    if(this._voicesInUse.getValueAtTime(t) < this.polyValue) {
-      currentVoice = this._voicesInUse.getValueAtTime(t);
+    if(this._voicesInUse.getValueAtTime(t) < this.maxVoices) {
+      currentVoice = Math.max(~~this._voicesInUse.getValueAtTime(t), 0);
     }
     //If we are exceeding the polyvalue, bump off the oldest notes and replace
     //with a new note
@@ -211,12 +212,11 @@ define(function (require) {
 
       var oldestNote = p5.prototype.freqToMidi(this.audiovoices[this._oldest].oscillator.freq().value);
       this.noteRelease(oldestNote);
-      this._oldest = ( this._oldest + 1 ) % (this.polyValue - 1);
+      this._oldest = ( this._oldest + 1 ) % (this.maxVoices - 1);
     }
 
-    //Overrite the entry in the notes object. A note (frequency value) 
+    //Overrite the entry in the notes object. A note (frequency value)
     //corresponds to the index of the audiovoice that is playing it
-
     this.notes[note] = new TimelineSignal();
     this.notes[note].setValueAtTime(currentVoice,t);
 
@@ -229,7 +229,6 @@ define(function (require) {
     this._updateAfter(t, 1);
 
     this._newest = currentVoice;
-
     //The audiovoice handles the actual scheduling of the note
     if (typeof velocity === 'number') {
       var maxRange = 1 / this._voicesInUse.getValueAtTime(t) * 2;
@@ -241,7 +240,7 @@ define(function (require) {
   /**
    * Private method to ensure accurate values of this._voicesInUse
    * Any time a new value is scheduled, it is necessary to increment all subsequent
-   * scheduledValues after attack, and decrement all subsequent 
+   * scheduledValues after attack, and decrement all subsequent
    * scheduledValues after release
    *
    * @private
@@ -250,7 +249,6 @@ define(function (require) {
    * @return {[type]}       [description]
    */
   p5.PolySynth.prototype._updateAfter = function(time, value) {
-
     if(this._voicesInUse._searchAfter(time) === null) {
       return;
     } else{
@@ -265,12 +263,12 @@ define(function (require) {
    *  Trigger the Release of an AudioVoice note. This is similar to releasing
    *  the key on a piano and letting the sound fade according to the
    *  release level and release time.
-   *  
+   *
    *  @method  noteRelease
    *  @param  {Number} [note]           midi note on which attack should be triggered.
    *  @param  {Number} [secondsFromNow] time to trigger the release
-   *  
-   */  
+   *
+   */
 
   p5.PolySynth.prototype.noteRelease = function (_note,secondsFromNow) {
     //Make sure note is in frequency inorder to query the this.notes object
@@ -281,24 +279,25 @@ define(function (require) {
       var tFromNow = secondsFromNow || 0;
       var t = now + tFromNow;
 
-    
+
     if (this.notes[note].getValueAtTime(t) === null) {
       console.warn('Cannot release a note that is not already playing');
     } else {
-      
+
 
       //Find the scheduled change in this._voicesInUse that will be previous to this new note
       //subtract 1 and schedule this value at time 't', when this note will stop playing
-      var previousVal = this._voicesInUse._searchBefore(t) === null ? 0 : this._voicesInUse._searchBefore(t).value;
+      var previousVal = Math.max(~~this._voicesInUse.getValueAtTime(t).value, 1);
       this._voicesInUse.setValueAtTime(previousVal - 1, t);
-      //Then update all scheduled values that follow to decrease by 1
-      this._updateAfter(t, -1);
+      //Then update all scheduled values that follow to decrease by 1 but never go below 0
+      if (previousVal > 0) {
+        this._updateAfter(t, -1);
+      }
 
       this.audiovoices[ this.notes[note].getValueAtTime(t) ].triggerRelease(tFromNow);
-      
       this.notes[note].setValueAtTime( null, t);
 
-      this._newest = this._newest === 0 ? 0 : (this._newest - 1) % (this.polyValue - 1);
+      this._newest = this._newest === 0 ? 0 : (this._newest - 1) % (this.maxVoices - 1);
     }
 
   };

--- a/test/test.js
+++ b/test/test.js
@@ -6,10 +6,21 @@ require.config({
 	}
 });
 
-var allTests = ['tests/p5.SoundFile', 'tests/p5.Amplitude', 
-	'tests/p5.Oscillator', 'tests/p5.Distortion', 
-	'tests/p5.Effect','tests/p5.Filter', 'tests/p5.FFT', 'tests/p5.Compressor',
-	'tests/p5.EQ', 'tests/p5.AudioIn'];
+var allTests = [
+	'tests/p5.SoundFile',
+	'tests/p5.Amplitude',
+	'tests/p5.Oscillator',
+	'tests/p5.Distortion',
+	'tests/p5.Effect',
+	'tests/p5.Filter',
+	'tests/p5.FFT',
+	'tests/p5.Compressor',
+	'tests/p5.EQ',
+	'tests/p5.AudioIn',
+	'tests/p5.AudioVoice',
+	'tests/p5.MonoSynth',
+	'tests/p5.PolySynth'
+];
 
 p5.prototype.masterVolume(0);
 

--- a/test/tests/p5.AudioVoice.js
+++ b/test/tests/p5.AudioVoice.js
@@ -1,0 +1,21 @@
+define(['chai'],
+  function(chai) {
+
+  var expect = chai.expect;
+
+  describe('p5.AudioVoice', function() {
+
+    it('can be created and disposed', function() {
+      var av = new p5.AudioVoice();
+      av.dispose();
+    });
+
+    it('can convert strings to frequency values', function() {
+      var av = new p5.AudioVoice();
+      var freq = av._setNote("A4");
+      expect(freq).to.equal(440);
+      av.dispose();
+    });
+  });
+
+});

--- a/test/tests/p5.MonoSynth.js
+++ b/test/tests/p5.MonoSynth.js
@@ -1,0 +1,26 @@
+define(['chai'],
+  function(chai) {
+
+  var expect = chai.expect;
+
+  describe('p5.MonoSynth', function() {
+
+    it('can be created and disposed', function() {
+      var monoSynth = new p5.MonoSynth();
+      monoSynth.dispose();
+    });
+
+    it('can play a note string', function(done) {
+      var monoSynth = new p5.MonoSynth();
+      monoSynth.play('A2');
+
+      // wait for scheduled value to complete
+      setTimeout(function() {
+        expect(monoSynth.oscillator.freq().value).to.equal(110);
+        monoSynth.dispose();
+        done();
+      }, 1);
+    });
+  });
+
+});

--- a/test/tests/p5.PolySynth.js
+++ b/test/tests/p5.PolySynth.js
@@ -1,0 +1,37 @@
+define(['chai'],
+  function(chai) {
+
+  var expect = chai.expect;
+
+  describe('p5.PolySynth', function() {
+    var audioContext = p5.prototype.getAudioContext();
+
+    it('can be created and disposed', function() {
+      var polySynth = new p5.PolySynth();
+      polySynth.dispose();
+    });
+
+    it('keeps track of the number of voicesInUse', function() {
+      var polySynth = new p5.PolySynth();
+      var noteDuration = 0.01;
+
+      var noteTriggerTime = audioContext.currentTime;
+      var noteActiveTime = noteTriggerTime + noteDuration/2;
+      var noteDoneTime = noteTriggerTime + noteDuration;
+
+      expect(polySynth._voicesInUse.getValueAtTime(noteTriggerTime)).to.equal(0);
+
+      polySynth.play('A2', 0, 0, noteDuration);
+      expect(polySynth._voicesInUse.getValueAtTime(noteActiveTime)).to.equal(1);
+      polySynth.play('A3', 0, 0, noteDuration);
+      expect(polySynth._voicesInUse.getValueAtTime(noteActiveTime)).to.equal(2);
+      polySynth.play('A4', 0, 0, noteDuration);
+      expect(polySynth._voicesInUse.getValueAtTime(noteActiveTime)).to.equal(3);
+
+      expect(polySynth._voicesInUse.getValueAtTime(noteDoneTime)).to.equal(0);
+
+      polySynth.dispose();
+    });
+  });
+
+});


### PR DESCRIPTION
Dug into the synth classes in response to https://github.com/processing/p5.js-sound/issues/266, they have a solid foundation and I'm excited to do more with them!

Apologies for this somewhat large PR, I'll break it down into smaller pieces...

- fix some dispose issues that made examples break if you try to reset them. (I think a better solution for this might be to set a flag on the dispose method so that everything can only be disposed of once)

- update monoSynth and PolySynth inline examples to use Note Strings as discussed in https://github.com/processing/p5.js-sound/issues/266

- fix PolySynth currentVoice counting as discussed in https://github.com/processing/p5.js-sound/issues/266 - the fixes are [here](https://github.com/processing/p5.js-sound/commit/762c76fb1fae9447841eeb84bec687ec68071aa5) and [here](https://github.com/processing/p5.js-sound/commit/1a07a823e588c54de5ae40d34aa5e90aa558c59f) - fixes a bug that sometimes resulted in negative or NaN values

- update p5 lib so that we can use `random(fromArray)` - might wanna move this to a separate PR

- use strings in the synth examples (i.e. "C3") instead of midi numbers which were getting interpreted as really low frequencies

- add inline attack/release examples to synth classes to show how to make them more interactive


I'd like to write some basic tests for the synths, and organize this PR a bit, while taking in any feedback in the meantime.

If you'd like to try the documentation examples in the context of the actual p5js website, try following [this recently updated guide](https://github.com/processing/p5.js-sound/wiki/Documentation#preview-documentation) on the wiki!

