### PR TITLE
Remove wrong parameter 'note' in polysynth setADSR docs

### DIFF
--- a/src/polysynth.js
+++ b/src/polysynth.js
@@ -197,7 +197,6 @@ define(function (require) {
    * monosynth so that all notes are played with this envelope.
    *
    *  @method  setADSR
-   *  @param {Number} [note]        Midi note on which ADSR should be set.
    *  @param {Number} [attackTime]  Time (in seconds before envelope
    *                                reaches Attack Level
    *  @param {Number} [decayTime]   Time (in seconds) before envelope


### PR DESCRIPTION
Fixes small error in docs: `PolySynth.setADSR` does not have a `note` input parameter, but the docs say that it does. This removes that extra parameter in the docs.