### PR TITLE
Fix bug in pause, forgot to use currentTime to schedule pause

### DIFF
--- a/src/soundLoop.js
+++ b/src/soundLoop.js
@@ -117,8 +117,9 @@ define(function (require) {
    */
   p5.SoundLoop.prototype.pause  = function(timeFromNow) {
     var t = timeFromNow || 0;
+    var now = p5sound.audiocontext.currentTime;
     if (this.isPlaying) {
-      this.clock.pause(t);
+      this.clock.pause(now + t);
       this.isPlaying = false;
     }
   };


### PR DESCRIPTION
Fix for the error described in #286 . Small mistake, forgot to use `ac.currentTime` to schedule the pause. 