### PR TITLE
synth play method has a default sustain

### DIFF
--- a/examples/_monosynth_basic/sketch.js
+++ b/examples/_monosynth_basic/sketch.js
@@ -14,7 +14,7 @@ function setup() {
 
 function mousePressed() {
   // pick a random midi note
-  var midiVal = round( random(50,72) );
+  var midiVal = midiToFreq(round( random(50,72) ));
   monoSynth.triggerAttack(midiVal, random() );
 }
 

--- a/src/audioVoice.js
+++ b/src/audioVoice.js
@@ -17,23 +17,6 @@ define(function() {
 	  p5sound.soundArray.push(this);
   };
 
-  /**
-   * This method converts midi notes specified as a string "C4", "Eb3"...etc
-   * to frequency
-   * @private
-   * @method  _setNote
-   * @param {String} note 
-   */
-  p5.AudioVoice.prototype._setNote = function(note) {
-    var wholeNotes = {A:21, B:23, C:24, D:26, E:28, F:29, G:31};
-    var value = wholeNotes[ note[0] ];
-    var octave = typeof Number(note.slice(-1)) === 'number'? note.slice(-1) : 0;
-    value += 12 * octave;
-    value = note[1] === '#' ? value+1 : note[1] ==='b' ? value - 1 : value;
-    //return midi value converted to frequency
-    return p5.prototype.midiToFreq(value);
-  };
-
   p5.AudioVoice.prototype.play = function (note, velocity, secondsFromNow, sustime) {
   };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -65,9 +65,32 @@ define(function (require) {
    *  }
    *  </code></div>
    */
-  p5.prototype.midiToFreq = function(m) {
+  var midiToFreq = p5.prototype.midiToFreq = function(m) {
     return 440 * Math.pow(2, (m-69)/12.0);
   };
+
+  // This method converts ANSI notes specified as a string "C4", "Eb3" to a frequency
+  noteToFreq = function(note) {
+    if (typeof note !== 'string') {
+      return note;
+    }
+    var wholeNotes = {A:21, B:23, C:24, D:26, E:28, F:29, G:31};
+    var value = wholeNotes[ note[0].toUpperCase() ];
+    var octave = ~~note.slice(-1);
+    value += 12 * (octave -1);
+
+    switch(note[1]) {
+      case '#':
+        value += 1;
+        break;
+      case 'b':
+        value -= 1;
+        break;
+      default:
+        break;
+    }
+    return midiToFreq(value);
+  }
 
   /**
    *  List the SoundFile formats that you will include. LoadSound
@@ -202,7 +225,8 @@ define(function (require) {
   };
 
   return {
-    midiToFreq: p5.prototype.midiToFreq
+    midiToFreq: midiToFreq,
+    noteToFreq: noteToFreq
   };
 
 });

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -3,6 +3,9 @@ define(function (require) {
 
   var p5sound = require('master');
   var AudioVoice = require('audioVoice');
+  var noteToFreq = require('helpers').noteToFreq;
+
+  var DEFAULT_SUSTAIN = 0.15;
 
   /**
     *  A MonoSynth is used as a single voice for sound synthesis.
@@ -125,12 +128,8 @@ define(function (require) {
     *
     */
   p5.MonoSynth.prototype.play = function (note, velocity, secondsFromNow, susTime) {
-    // set range of env (TO DO: allow this to be scheduled in advance)
-    if (typeof susTime === 'number') {
-      this.susTime = susTime;
-    }
     this.triggerAttack(note, velocity, ~~secondsFromNow);
-    this.triggerRelease(~~secondsFromNow + susTime);
+    this.triggerRelease(~~secondsFromNow + (susTime || DEFAULT_SUSTAIN));
   };
 
   /**
@@ -160,10 +159,8 @@ define(function (require) {
      *  </code></div>
      */
   p5.MonoSynth.prototype.triggerAttack = function (note, velocity, secondsFromNow) {
-    var secondsFromNow = secondsFromNow || 0;
-    //triggerAttack uses ._setNote to convert a midi string to a frequency if necessary
-    var freq = typeof note === 'string' ? this._setNote(note)
-      : typeof note === 'number' ? note : 440;
+    var secondsFromNow = ~~secondsFromNow;
+    var freq = noteToFreq(note);
     var vel = velocity || 0.1;
     this._isOn = true;
     this.oscillator.freq(freq, 0, secondsFromNow);

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -126,10 +126,11 @@ define(function (require) {
     */
   p5.MonoSynth.prototype.play = function (note, velocity, secondsFromNow, susTime) {
     // set range of env (TO DO: allow this to be scheduled in advance)
-    var susTime = susTime || this.sustain;
-    this.susTime = susTime;
-    this.triggerAttack(note, velocity, secondsFromNow);
-    this.triggerRelease(secondsFromNow + susTime);
+    if (typeof susTime === 'number') {
+      this.susTime = susTime;
+    }
+    this.triggerAttack(note, velocity, ~~secondsFromNow);
+    this.triggerRelease(~~secondsFromNow + susTime);
   };
 
   /**
@@ -160,11 +161,10 @@ define(function (require) {
      */
   p5.MonoSynth.prototype.triggerAttack = function (note, velocity, secondsFromNow) {
     var secondsFromNow = secondsFromNow || 0;
-
     //triggerAttack uses ._setNote to convert a midi string to a frequency if necessary
     var freq = typeof note === 'string' ? this._setNote(note)
       : typeof note === 'number' ? note : 440;
-    var vel = velocity || 1;
+    var vel = velocity || 0.1;
     this._isOn = true;
     this.oscillator.freq(freq, 0, secondsFromNow);
     this.env.ramp(this.output, secondsFromNow, vel);

--- a/src/polysynth.js
+++ b/src/polysynth.js
@@ -363,7 +363,8 @@ define(function (require) {
       });
       this._voicesInUse.setValueAtTime(0, t);
       for (var n in this.notes) {
-        this.notes[n].setValueAtTime(null, t)
+        this.notes[n].dispose();
+        delete this.notes[n];
       }
       return;
     }
@@ -371,7 +372,7 @@ define(function (require) {
     //Make sure note is in frequency inorder to query the this.notes object
     var note = noteToFreq(_note);
 
-    if (this.notes[note].getValueAtTime(t) === null) {
+    if (!this.notes[note] || this.notes[note].getValueAtTime(t) === null) {
       console.warn('Cannot release a note that is not already playing');
     } else {
       //Find the scheduled change in this._voicesInUse that will be previous to this new note
@@ -384,7 +385,8 @@ define(function (require) {
       }
 
       this.audiovoices[ this.notes[note].getValueAtTime(t) ].triggerRelease(tFromNow);
-      this.notes[note].setValueAtTime( null, t);
+      this.notes[note].dispose();
+      delete this.notes[note];
 
       this._newest = this._newest === 0 ? 0 : (this._newest - 1) % (this.maxVoices - 1);
     }

--- a/src/polysynth.js
+++ b/src/polysynth.js
@@ -1,11 +1,9 @@
 'use strict';
 define(function (require) {
 
-
   var p5sound = require('master');
   var TimelineSignal = require('Tone/signal/TimelineSignal');
-  require('sndcore');
-
+  var noteToFreq = require('helpers').noteToFreq;
 
   /**
     *  An AudioVoice is used as a single voice for sound synthesis.
@@ -247,30 +245,27 @@ define(function (require) {
    *  </code></div>
    */
   p5.PolySynth.prototype.noteAttack = function (_note, _velocity, secondsFromNow) {
-    var now =  p5sound.audiocontext.currentTime;
-
     //this value goes to the audiovoices which handle their own scheduling
-    var tFromNow = secondsFromNow || 0;
+    var secondsFromNow = ~~secondsFromNow;
 
     //this value is used by this._voicesInUse
-    var t = now + tFromNow;
+    var acTime = p5sound.audiocontext.currentTime + secondsFromNow;
 
     //Convert note to frequency if necessary. This is because entries into this.notes
     //should be based on frequency for the sake of consistency.
-    var note = typeof _note === 'string' ? this.AudioVoice.prototype._setNote(_note)
-      : typeof _note === 'number' ? _note : 440;
-    var velocity = _velocity === undefined ? 1 : _velocity;
+    var note = noteToFreq(_note);
+    var velocity = _velocity || 0.1;
 
     var currentVoice;
 
     //Release the note if it is already playing
-    if ( this.notes[note] !== undefined && this.notes[note].getValueAtTime(t) !== null) {
-      this.noteRelease(note,0);
+    if (this.notes[note] && this.notes[note].getValueAtTime(acTime) !== null) {
+      this.noteRelease(note, 0);
     }
 
     //Check to see how many voices are in use at the time the note will start
-    if(this._voicesInUse.getValueAtTime(t) < this.maxVoices) {
-      currentVoice = Math.max(~~this._voicesInUse.getValueAtTime(t), 0);
+    if (this._voicesInUse.getValueAtTime(acTime) < this.maxVoices) {
+      currentVoice = Math.max(~~this._voicesInUse.getValueAtTime(acTime), 0);
     }
     //If we are exceeding the polyvalue, bump off the oldest notes and replace
     //with a new note
@@ -285,23 +280,23 @@ define(function (require) {
     //Overrite the entry in the notes object. A note (frequency value)
     //corresponds to the index of the audiovoice that is playing it
     this.notes[note] = new TimelineSignal();
-    this.notes[note].setValueAtTime(currentVoice,t);
+    this.notes[note].setValueAtTime(currentVoice, acTime);
 
     //Find the scheduled change in this._voicesInUse that will be previous to this new note
     //Add 1 and schedule this value at time 't', when this note will start playing
-    var previousVal = this._voicesInUse._searchBefore(t) === null ? 0 : this._voicesInUse._searchBefore(t).value;
-    this._voicesInUse.setValueAtTime(previousVal + 1, t);
+    var previousVal = this._voicesInUse._searchBefore(acTime) === null ? 0 : this._voicesInUse._searchBefore(acTime).value;
+    this._voicesInUse.setValueAtTime(previousVal + 1, acTime);
 
     //Then update all scheduled values that follow to increase by 1
-    this._updateAfter(t, 1);
+    this._updateAfter(acTime, 1);
 
     this._newest = currentVoice;
     //The audiovoice handles the actual scheduling of the note
     if (typeof velocity === 'number') {
-      var maxRange = 1 / this._voicesInUse.getValueAtTime(t) * 2;
+      var maxRange = 1 / this._voicesInUse.getValueAtTime(acTime) * 2;
       velocity = velocity > maxRange ? maxRange : velocity;
     }
-    this.audiovoices[currentVoice].triggerAttack(note, velocity, tFromNow);
+    this.audiovoices[currentVoice].triggerAttack(note, velocity, secondsFromNow);
   };
 
   /**
@@ -374,8 +369,7 @@ define(function (require) {
     }
 
     //Make sure note is in frequency inorder to query the this.notes object
-    var note = typeof _note === 'string' ? this.AudioVoice.prototype._setNote(_note)
-      : typeof _note === 'number' ? _note : this.audiovoices[this._newest].oscillator.freq().value;
+    var note = noteToFreq(_note);
 
     if (this.notes[note].getValueAtTime(t) === null) {
       console.warn('Cannot release a note that is not already playing');


### PR DESCRIPTION
- add a `DEFAULT_SUSTAIN` to the monosynth so that we can call `play('a4')`  without providing any additional parameters

And a few small tweaks:
- move `noteToFreq` to helpers
- fix octave in ANSI note conversion (`value += 12 * (octave -1);`)
- allow for lower case ANSI notes like "a4"
- dispose of polysynth TimelineSignal on noteRelease - otherwise these were not getting garbage collected and a potential memory issue