### PR TITLE
patch monosynth velocity

### DIFF
--- a/src/master.js
+++ b/src/master.js
@@ -12,8 +12,9 @@ define(function () {
 
     //put a hard limiter on the output
     this.limiter = audiocontext.createDynamicsCompressor();
-    this.limiter.threshold.value = 0;
+    this.limiter.threshold.value = -3;
     this.limiter.ratio.value = 20;
+    this.limiter.knee.value = 1;
 
     this.audiocontext = audiocontext;
 

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -71,10 +71,6 @@ define(function (require) {
     this.oscillator.start();
     this.connect();
 
-    //Audiovoices are connected to soundout by default
-
-    this._isOn = false;
-
     p5sound.soundArray.push(this);
   };
 
@@ -159,7 +155,6 @@ define(function (require) {
     var secondsFromNow = ~~secondsFromNow;
     var freq = noteToFreq(note);
     var vel = velocity || 0.1;
-    this._isOn = true;
     this.oscillator.freq(freq, 0, secondsFromNow);
     this.env.ramp(this.output.gain, secondsFromNow, vel);
   };
@@ -187,7 +182,6 @@ define(function (require) {
   p5.MonoSynth.prototype.triggerRelease = function (secondsFromNow) {
     var secondsFromNow = secondsFromNow || 0;
     this.env.ramp(this.output.gain, secondsFromNow, 0);
-    this._isOn = false;
   };
 
   /**

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -50,7 +50,6 @@ define(function (require) {
     AudioVoice.call(this);
 
     this.oscillator = new p5.Oscillator();
-    // this.oscillator.disconnect();
 
     this.env = new p5.Envelope();
     this.env.setRange(1, 0);
@@ -59,17 +58,15 @@ define(function (require) {
     //set params
     this.setADSR(0.02, 0.25, 0.05, 0.35);
 
-    // filter
-    this.filter = new p5.Filter('highpass');
-    this.filter.set(5, 1);
-
-    // oscillator --> env --> filter --> this.output (gain) --> p5.soundOut
+    // oscillator --> env --> this.output (gain) --> p5.soundOut
     this.oscillator.disconnect();
-    this.oscillator.connect(this.filter);
+    this.oscillator.connect(this.output);
+
     this.env.disconnect();
-    this.env.setInput(this.oscillator);
-    // this.env.connect(this.filter);
-    this.filter.connect(this.output);
+    this.env.setInput(this.output.gain);
+
+    // reset oscillator gain to 1.0
+    this.oscillator.output.gain.value = 1.0;
 
     this.oscillator.start();
     this.connect();
@@ -164,7 +161,7 @@ define(function (require) {
     var vel = velocity || 0.1;
     this._isOn = true;
     this.oscillator.freq(freq, 0, secondsFromNow);
-    this.env.ramp(this.output, secondsFromNow, vel);
+    this.env.ramp(this.output.gain, secondsFromNow, vel);
   };
 
   /**
@@ -189,7 +186,7 @@ define(function (require) {
      */
   p5.MonoSynth.prototype.triggerRelease = function (secondsFromNow) {
     var secondsFromNow = secondsFromNow || 0;
-    this.env.ramp(this.output, secondsFromNow, 0);
+    this.env.ramp(this.output.gain, secondsFromNow, 0);
     this._isOn = false;
   };
 
@@ -319,9 +316,6 @@ define(function (require) {
   p5.MonoSynth.prototype.dispose = function() {
     AudioVoice.prototype.dispose.apply(this);
 
-    if (this.filter) {
-      this.filter.dispose();
-    }
     if (this.env) {
       this.env.dispose();
     }


### PR DESCRIPTION
This should fix https://github.com/processing/p5.js-sound/issues/301 
- Monosynth envelope ramps `this.output.gain` — the audio param — instead of `this.output`
- [Update master limiter knee and threshold](https://github.com/processing/p5.js-sound/commit/9607a544e94246649f3a724425121762786dcae6) so that it is better suited to prevent clipping. Specifying a sharp `knee` value makes a big difference, as does lowering the ratio slightly. We don't want to change the quality of sound unless it's nearly clipping.
- remove some unused monosynth properties (_isOn and filter)