### PR TITLE
removed line from p5.Filter.prototype.freq which sets the frequency b…

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -162,7 +162,6 @@ define(function (require) {
       freq = 1;
     }
     if (typeof freq === 'number') {
-      this.biquad.frequency.value = freq;
       this.biquad.frequency.cancelScheduledValues(this.ac.currentTime + 0.01 + t);
       this.biquad.frequency.exponentialRampToValueAtTime(freq, this.ac.currentTime + 0.02 + t);
     } else if (freq) {


### PR DESCRIPTION
…efore the exponential ramp, which was essentially ignoring the 'time' argument passed to the method