### PR TITLE
Used sampleRate from AudioContext for saving rather than hardcoded 44100

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -259,8 +259,8 @@ define(function (require) {
     view.setUint16(20, 1, true);
     // stereo (2 channels)
     view.setUint16(22, 2, true);
-    view.setUint32(24, 44100, true);
-    view.setUint32(28, 44100 * 4, true);
+    view.setUint32(24, p5sound.audiocontext.sampleRate, true);
+    view.setUint32(28, p5sound.audiocontext.sampleRate * 4, true);
     view.setUint16(32, 4, true);
     view.setUint16(34, 16, true);
     // data sub-chunk


### PR DESCRIPTION
The ```convertToWav(audioBuffer)``` function hardcoded 44100 for the sample rate, which saved the buffer to a file correctly, but set the sample rate wrong if the buffer's sample rate was different (e.g., 48000). One could just alter the file after, but this saves the buffer to a wave file with the sampleRate from the AudioContext.