### PR TITLE
Fixing minifying problem from es6 to es5

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,8 +142,14 @@ module.exports = function(grunt) {
               });
            }
           },
-          optimize: 'uglify2',
-          out: 'lib/p5.sound.min.js',
+          optimize: 'none',
+          out: function(text, sourceMapText) {
+
+            var UglifyJS = require('uglify-es'),
+                uglified = UglifyJS.minify(text);
+
+            grunt.file.write('lib/p5.sound.min.js', uglified.code);
+          },
           paths: '<%= requirejs.unmin.options.paths %>',
           useStrict: true,
           wrap: {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-eslint": "^20.0.0",
     "grunt-mocha": "^1.0.4",
-    "grunt-open": "^0.2.3"
+    "grunt-open": "^0.2.3",
+    "uglify-es": "^3.3.9"
   },
   "dependencies": {
     "startaudiocontext": "^1.2.1",


### PR DESCRIPTION
Fixes #348  (upgrade build tools so that we can use ES6+ conventions in source code)

@therewasaguy can you review this?