### PR TITLE
only add audioworklet modules once

### DIFF
--- a/src/audioWorklet/index.js
+++ b/src/audioWorklet/index.js
@@ -6,6 +6,8 @@ const moduleSources = [
 ];
 const ac = p5sound.audiocontext;
 
+let initializedAudioWorklets = false;
+
 function loadAudioWorkletModules() {
   return Promise.all(moduleSources.map(function(moduleSrc) {
     const blob = new Blob([moduleSrc], { type: 'application/javascript' });
@@ -15,13 +17,16 @@ function loadAudioWorkletModules() {
 }
 
 p5.prototype.registerMethod('init', function() {
+  if (initializedAudioWorklets) return;
   // ensure that a preload function exists so that p5 will wait for preloads to finish
   if (!this.preload && !window.preload) {
     this.preload = function() {};
   }
+
   // use p5's preload system to load necessary AudioWorklet modules before setup()
-  this._preloadCount++;
+  this._incrementPreload();
   const onWorkletModulesLoad = function() {
+    initializedAudioWorklets = true;
     this._decrementPreload();
   }.bind(this);
   loadAudioWorkletModules().then(onWorkletModulesLoad);


### PR DESCRIPTION
This Promise `return ac.audioWorklet.addModule(objectURL)` was throwing an error if the worklet with that name had already been registered on the page.

We run into this issue when p5 is in "instance mode" (i.e. on the documentation examples at p5js.org) because the "init" callback can run multiple times for each instance.

cc @oshoham