### PR TITLE
Broken Link in documentation fix

### DIFF
--- a/src/audioin.js
+++ b/src/audioin.js
@@ -252,9 +252,10 @@ define(function (require) {
 
   /**
    * Returns a list of available input sources. This is a wrapper
-   * for <a title="MediaDevices.enumerateDevices() - Web APIs | MDN" target="_blank" href=
+   * for <a target="_blank" href=
    *  "https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices"
-   *  > and it returns a Promise.
+   *  >MediaDevices.enumerateDevices() - Web APIs | MDN</a>
+   * and it returns a Promise.
    *
    * @method  getSources
    * @for p5.AudioIn


### PR DESCRIPTION

[Error.txt](https://github.com/processing/p5.js-sound/files/3720700/Error.txt)
This should in theory fix the broken link from the issue #384. The problem is, for some reason, I can't manage to rebuild the lib js or run the linter at all, since I get this error (file attached). Any ideas? I can do the same with p5.js repo with no problem at all