### PR TITLE
Fix wrong `splice` method call in `_clearOnEnd` function

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -1773,7 +1773,7 @@ define(function (require) {
 
     soundFile.bufferSourceNodes.forEach(function (n, i) {
       if (n._playing === false) {
-        soundFile.bufferSourceNodes.splice(i);
+        soundFile.bufferSourceNodes.splice(i, 1);
       }
     });
 


### PR DESCRIPTION
Fix wrong `splice` method call in `_clearOnEnd` function.