### PR TITLE
Fix deletion of array elements in iteration

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -1771,9 +1771,13 @@ define(function (require) {
     // call the onended callback
     soundFile._onended(soundFile);
 
-    soundFile.bufferSourceNodes.forEach(function (n, i) {
+    // delete bufferSourceNode(s) in soundFile.bufferSourceNodes
+    // iterate in reverse order because the index changes by splice
+    soundFile.bufferSourceNodes.map((_, i) => i).reverse().forEach(function (i) {
+      const n = soundFile.bufferSourceNodes[i];
+
       if (n._playing === false) {
-        soundFile.bufferSourceNodes.splice(i);
+        soundFile.bufferSourceNodes.splice(i, 1);
       }
     });
 


### PR DESCRIPTION
Fix deletion of array elements in iteration.

- Add the second argument `1` for `splice`
- Iterate in reverse order since the index changes by `splice`

[see this logic works](https://jsfiddle.net/osfdt0z6/)