### PR TITLE
Grunt dev task also decomments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('lint', ['eslint:source']);
   grunt.registerTask('default', ['webpack:prod', 'decomment']);
-  grunt.registerTask('dev', ['connect','webpack:dev']);
+  grunt.registerTask('dev', ['connect','webpack:dev', 'decomment']);
   grunt.registerTask('serve', 'connect:server:keepalive');
   grunt.registerTask('run-tests', ['serve', 'open']);
 };


### PR DESCRIPTION
Decomment is necessary for the p5js website inline documentation to parse the jsdoc comments, but not the webpack comments