### PR TITLE
replaced depracated println method with console.log

### DIFF
--- a/examples/peakDetect/sketch.js
+++ b/examples/peakDetect/sketch.js
@@ -31,7 +31,7 @@ function setup() {
 
   src_length = source_file.duration();
   source_file.playMode('restart'); 
-  println("source duration: " +src_length);
+  console.log("source duration: " +src_length);
 
   // draw the waveform to an off-screen graphic
   var peaks = source_file.getPeaks(); // get an array of peaks

--- a/examples/peakDetection_offline/sketch.js
+++ b/examples/peakDetection_offline/sketch.js
@@ -17,7 +17,7 @@ function setup() {
 
   src_length = source_file.duration();
   source_file.playMode('restart'); 
-  println("source duration: " +src_length);
+  console.log("source duration: " + src_length);
 
   // find beat preprocessing the source file with lowpass
   var beats = source_file.processPeaks(onComplete);


### PR DESCRIPTION
The method to print to the native console that is println has been deprecated and that it must be replaced with a proper method which is "console.log" for native js consoles and for p5 web editor too .
# Proof of deprecation 
> https://github.com/processing/p5.js/issues/1614
# discussion on the forum for the same!
> https://discourse.processing.org/t/is-println-deprecated/19929
