### PR TITLE
Fixed buggy behaviour in part.onStep()

### DIFF
--- a/examples/looper_simple/sketch.js
+++ b/examples/looper_simple/sketch.js
@@ -37,8 +37,8 @@ function setup() {
 
   // // set tempo (Beats Per Minute) of the part and tell it to loop
   part.setBPM(60);
-  part.noLoop();
-  part.start();
+  // Using part.loop() instead of part.start() to call part.onStep() 8 times.
+  part.loop();
 
 }
 


### PR DESCRIPTION
Fixed issue #374 
Used part.loop() instead of part.start() to call part.onStep() 8 times for each loop as long as it is looping. 