### PR TITLE
monoSynth.triggerRelease() reaches the target value

### DIFF
--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -200,9 +200,10 @@ define(function (require) {
      *  }
      *  </code></div>
      */
-  p5.MonoSynth.prototype.triggerRelease = function (secondsFromNow) {
+  p5.MonoSynth.prototype.triggerRelease = function (secondsFromNow, targetValue) {
+    var targetValue = targetValue || 0;
     var secondsFromNow = secondsFromNow || 0;
-    this.env.ramp(this.output.gain, secondsFromNow, 0);
+    this.env.ramp(this.output.gain, secondsFromNow, targetValue);
   };
 
   /**


### PR DESCRIPTION
Fixed issue #304 
Initialized the targetValue of ramp function for monoSynth.triggerRelease() so it reaches the target value of 0.  