### PR TITLE
fixed abnormal behaviour of audio output in p5.signal example

### DIFF
--- a/src/signal.js
+++ b/src/signal.js
@@ -39,7 +39,6 @@ define(function (require) {
    *    text('tap to play', 20, 20);
    *
    *    carrier = new p5.Oscillator('sine');
-   *    carrier.start();
    *    carrier.amp(1); // set amplitude
    *    carrier.freq(220); // set frequency
    *
@@ -58,6 +57,7 @@ define(function (require) {
    *  function canvasPressed() {
    *    userStartAudio();
    *    carrier.amp(1.0);
+   *    carrier.start();
    *  }
    *
    *  function mouseReleased() {

--- a/src/signal.js
+++ b/src/signal.js
@@ -31,6 +31,7 @@ define(function (require) {
    *  @example
    *  <div><code>
    *  let carrier, modulator;
+   *  let hasStarted = false;
    *
    *  function setup() {
    *    let cnv = createCanvas(100, 100);
@@ -57,7 +58,10 @@ define(function (require) {
    *  function canvasPressed() {
    *    userStartAudio();
    *    carrier.amp(1.0);
-   *    carrier.start();
+   *    if(!hasStarted){
+   *      carrier.start();
+   *      hasStarted = true;
+   *    }
    *  }
    *
    *  function mouseReleased() {


### PR DESCRIPTION
fixes #471 

before :
 `carrier.start()`  was placed inside setup function, and as soon as the script get rendered , user hears a all of a sudden sound of carrier node without the user consent :grimacing: !! 

after:
`carrier.start()` has been placed inside the `canvasPressed()` which ensures that output signal is heard by user when it Presses the canvas ! :grinning: 