### PR TITLE
Default to 0 if arraySequence[0] is undefined

### DIFF
--- a/src/audioWorklet/ringBuffer.js
+++ b/src/audioWorklet/ringBuffer.js
@@ -63,7 +63,7 @@ class RingBuffer {
     // match with this buffer obejct.
 
     // Transfer data from the |arraySequence| storage to the internal buffer.
-    let sourceLength = arraySequence[0].length;
+    let sourceLength = arraySequence[0] ? arraySequence[0].length : 0;
     for (let i = 0; i < sourceLength; ++i) {
       let writeIndex = (this._writeIndex + i) % this._length;
       for (let channel = 0; channel < this._channelCount; ++channel) {


### PR DESCRIPTION
An error is logged to the console when calling `p5.SoundFile.play()`
<img width="617" alt="Screen Shot 2020-08-23 at 9 24 08 PM" src="https://user-images.githubusercontent.com/6127892/91004257-881aeb80-e588-11ea-85d8-8931dc0e76fd.png">

It happens because the SoundFileProcessor sends `[undefined]` to the `ringBuffer` some of the time. 
https://github.com/processing/p5.js-sound/blob/master/src/audioWorklet/soundFileProcessor.js#L18

Causing the `AudioWorkletNode` `onmessage` callback to not fire, which results in `p5.SoundFile.currentTime()` always returning 0.
https://github.com/processing/p5.js-sound/blob/master/src/soundfile.js#L1353-L1364

This change removes the console error and make `currentTime()` behave correctly.