### PR TITLE
fix SoundFile.processPeaks()

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -1515,6 +1515,7 @@ class SoundFile {
    *  @return {Array}                  Array of timestamped peaks
    */
   processPeaks(callback, _initThreshold, _minThreshold, _minPeaks) {
+    var self = this;
     var bufLen = this.buffer.length;
     var sampleRate = this.buffer.sampleRate;
     var buffer = this.buffer;


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-sound/issues/412

There is a `if (!self.panner) return;` check at https://github.com/processing/p5.js-sound/blob/b291d88d9bcb45905852fabbcbb2d8fff0999c00/src/soundfile.js#L1547 which always fails, because `self` variable is undefined.

Not sure if this is proper way to fix this, but it seems pretty obvious and the callback starts to work. 🙂 