### PR TITLE
p5.soundFile whileLoadingCallback support for FileReader

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -486,6 +486,9 @@ class SoundFile {
           onerror(e);
         }
       };
+      reader.addEventListener('progress', function (evt) {
+        self._updateProgress(evt);
+      });
       reader.readAsArrayBuffer(this.file);
     }
   }


### PR DESCRIPTION
The callback works fine for XHR requests, but the event was not registered for FileReader even though it's also supported by browsers (https://developer.mozilla.org/en-US/docs/Web/API/FileReader/progress_event).