### PR TITLE
Fix typo in bpm field of p5.soundLoop reference

### DIFF
--- a/lib/p5.sound.js
+++ b/lib/p5.sound.js
@@ -9735,7 +9735,7 @@ p5.SoundLoop.prototype._note = function (value) {
   return this._timeSignature / value;
 };
 /**
- * Getters and Setters, setting any paramter will result in a change in the clock's
+ * Getters and Setters, setting any parameter will result in a change in the clock's
  * frequency, that will be reflected after the next callback
  * beats per minute (defaults to 60)
  * @property {Number} bpm


### PR DESCRIPTION
Resolves #556 

Changes:
Earlier 'parameter' was spelled incorrectly in the bpm field of [**p5.SoundLoop reference**](https://p5js.org/reference/#/p5.SoundLoop)
This pr resolves that issue