### PR TITLE
Bug #571: fix excess onend events

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -898,7 +898,6 @@ class SoundFile {
         }
       }
       this._counterNode.stop(now + time);
-      this._onended(this);
     }
   }
 


### PR DESCRIPTION
- Allow the BufferSourceNode EventListener to deliver onend when stopAll
  is called. _clearOnEnd will call _onended and remove the
  EventListener.

Signed-off-by: Robert Collins <robertc@robertcollins.net>