### PR TITLE
add lib/p5.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ examples/__test
 p5soundnotes
 *.DS_Store
 .vscode
+lib/p5.*


### PR DESCRIPTION
It would be inconvenient if git tracks the changes made in the `lib/` directory after each build.

**Changes:**
- added `lib/p5.*` to `.gitignore`

[p5.js](https://github.com/processing/p5.js) repository also does not track the library after build (see [here](https://github.com/processing/p5.js/blob/main/.gitignore#L6)). @endurance21 I would love to hear your thoughts on this :)