### PR TITLE
Fixed function name mismatch in reference page of p5.Amplitude

### DIFF
--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -21,7 +21,7 @@ import processorNames from './audioWorklet/processorNames';
  *  }
  *  function setup() {
  *    let cnv = createCanvas(100,100);
- *    cnv.mouseClicked(toggleSound);
+ *    cnv.mouseClicked(togglePlay);
  *    amplitude = new p5.Amplitude();
  *  }
  *


### PR DESCRIPTION
# problem
In  PR #563 the name of function was changed but backward compatibility was not ensured.
https://github.com/processing/p5.js-sound/pull/563/commits/498061ee4d54b8886e6273b30df93e1ee5f10730

# solution
Added correct function name at required place.