### PR TITLE
Fixes in Reference Examples 

### DIFF
--- a/src/audioin.js
+++ b/src/audioin.js
@@ -31,7 +31,7 @@ p5sound.inputSources = [];
  *
  *   function setup(){
  *    let cnv = createCanvas(100, 100);
- *    cnv.mousePressed(useraudiocontextStartAudio);
+ *    cnv.mousePressed(userStartAudio);
  *    textAlign(CENTER);
  *    mic = new p5.AudioIn();
  *    mic.start();


### PR DESCRIPTION
# Problem
unwanted variable name .
it should be `useStartAudio` instead of `useraudiocontextstart` in inline example of p5.audioin
# Solution 
corrected the variable name