### PR TITLE
Fixing EQ test

### DIFF
--- a/src/looper.js
+++ b/src/looper.js
@@ -387,7 +387,7 @@ class Score {
   constructor() {
     // for all of the arguments
     this.parts = [];
-    this.currentPart = new Array(arguments.length);;
+    this.currentPart = new Array(arguments.length);
 
     var thisScore = this;
     for (var i in arguments) {
@@ -396,7 +396,7 @@ class Score {
       this.parts[i].onended = function () {
         thisScore.resetPart(i);
         playNextPart(thisScore);
-      };    
+      };
     }
     this.looping = false;
   }

--- a/test/tests/p5.EQ.js
+++ b/test/tests/p5.EQ.js
@@ -43,12 +43,17 @@ describe('p5.EQ', function () {
     expect(eq.bands[2].gain()).to.equal(30);
   });
 
-  it('a bands freq value can be changed', function () {
+  it('a bands freq value can be changed', function (done) {
     const eq = new p5.EQ(8);
-    expect(eq.bands[0].freq()).to.equal(100);
-    eq.bands[0].freq(200);
-    expect(eq.bands[0].gain()).to.equal(0);
-    expect(eq.bands[0].freq()).to.equal(200);
+    setTimeout(() => {
+      expect(eq.bands[0].freq()).to.equal(100);
+      eq.bands[0].freq(200);
+      setTimeout(() => {
+        expect(eq.bands[0].gain()).to.equal(0);
+        expect(eq.bands[0].freq()).to.equal(200);
+        done();
+      }, 100);
+    }, 50);
   });
 
   it('a bands type can be changed', function () {


### PR DESCRIPTION
@therewasaguy After lots of hour of debugging finally found out why the test is failing. When we pass 8 in EQ constructor it takes some time to initialize the freq but we are checking just after the setting that's why it is comparing with the default value i.e 350. Same issue when we are setting the freq to 200. But now it is fixed and working :)

can you please! review this?

screenshot
![TESTS](https://user-images.githubusercontent.com/61353484/117196347-fd230e00-ae03-11eb-96c0-b8b066d1ba23.png)
