### PR TITLE
(Gsoc'21) (Week-2) Fixes mic issues in recorder example

### DIFF
--- a/examples/record/sketch.js
+++ b/examples/record/sketch.js
@@ -2,9 +2,10 @@
 // We need p5.AudioIn (mic / sound source), p5.SoundRecorder
 // (records the sound), and a p5.SoundFile (play back).
 
-var mic, recorder, soundFile;
+let mic, recorder, soundFile;
 
-var state = 0; // mousePress will increment from Record, to Stop, to Play
+let state = 0; // mousePress will increment from state = 0 (Record), to 1(Stop), to 2(Play)
+
 
 function setup() {
   createCanvas(400, 400);
@@ -26,10 +27,11 @@ function setup() {
 }
 
 function mousePressed() {
+  userStartAudio();
   // use the '.enabled' boolean to make sure user enabled the mic (otherwise we'd record silence)
   if (state === 0) {
     // users must manually enable their browser microphone for recording to work properly!
-    mic.start(function() {
+    mic.start(function () {
       // Tell recorder to record to a p5.SoundFile which we will use for playback
       recorder.record(soundFile);
 

--- a/examples/record/sketch.js
+++ b/examples/record/sketch.js
@@ -7,16 +7,13 @@ var mic, recorder, soundFile;
 var state = 0; // mousePress will increment from Record, to Stop, to Play
 
 function setup() {
-  createCanvas(400,400);
+  createCanvas(400, 400);
   background(200);
   fill(0);
   text('Enable mic and click the mouse to begin recording', 20, 20);
 
   // create an audio in
   mic = new p5.AudioIn();
-
-  // users must manually enable their browser microphone for recording to work properly!
-  mic.start();
 
   // create a sound recorder
   recorder = new p5.SoundRecorder();
@@ -30,25 +27,23 @@ function setup() {
 
 function mousePressed() {
   // use the '.enabled' boolean to make sure user enabled the mic (otherwise we'd record silence)
-  if (state === 0 && mic.enabled) {
+  if (state === 0) {
+    // users must manually enable their browser microphone for recording to work properly!
+    mic.start(function() {
+      // Tell recorder to record to a p5.SoundFile which we will use for playback
+      recorder.record(soundFile);
 
-    // Tell recorder to record to a p5.SoundFile which we will use for playback
-    recorder.record(soundFile);
-
-    background(255,0,0);
-    text('Recording now! Click to stop.', 20, 20);
-    state++;
-  }
-
-  else if (state === 1) {
+      background(255, 0, 0);
+      text('Recording now! Click to stop.', 20, 20);
+      state++;
+    });
+  } else if (state === 1) {
     recorder.stop(); // stop recorder, and send the result to soundFile
-
-    background(0,255,0);
+    mic.dispose();
+    background(0, 255, 0);
     text('Recording stopped. Click to play', 20, 20);
     state++;
-  }
-
-  else if (state === 2) {
+  } else if (state === 2) {
     soundFile.play(); // play the result!
   }
 }

--- a/examples/record/sketch.js
+++ b/examples/record/sketch.js
@@ -4,7 +4,6 @@
 
 let mic, recorder, soundFile;
 
-let state = 0; // mousePress will increment from state = 0 (Record), to 1(Stop), to 2(Play)
 let isRecordingStarted = false;
 let isResultPlayed = false;
 

--- a/examples/record/sketch.js
+++ b/examples/record/sketch.js
@@ -5,7 +5,8 @@
 let mic, recorder, soundFile;
 
 let state = 0; // mousePress will increment from state = 0 (Record), to 1(Stop), to 2(Play)
-
+let isRecordingStarted = false;
+let isResultPlayed = false;
 
 function setup() {
   createCanvas(400, 400);
@@ -29,7 +30,7 @@ function setup() {
 function mousePressed() {
   userStartAudio();
   // use the '.enabled' boolean to make sure user enabled the mic (otherwise we'd record silence)
-  if (state === 0) {
+  if (!isRecordingStarted && !isResultPlayed) {
     // users must manually enable their browser microphone for recording to work properly!
     mic.start(function () {
       // Tell recorder to record to a p5.SoundFile which we will use for playback
@@ -37,15 +38,15 @@ function mousePressed() {
 
       background(255, 0, 0);
       text('Recording now! Click to stop.', 20, 20);
-      state++;
+      isRecordingStarted = true;
     });
-  } else if (state === 1) {
+  } else if (isRecordingStarted && !isResultPlayed) {
     recorder.stop(); // stop recorder, and send the result to soundFile
     mic.dispose();
     background(0, 255, 0);
     text('Recording stopped. Click to play', 20, 20);
-    state++;
-  } else if (state === 2) {
+    isResultPlayed = true;
+  } else if (isRecordingStarted && isResultPlayed) {
     soundFile.play(); // play the result!
   }
 }

--- a/index.html
+++ b/index.html
@@ -65,7 +65,6 @@
 <div><a href="examples/pause_soundfile">pause_soundfile</a></div>
 <div><a href="examples/peakDetect">peakDetect</a></div>
 <div><a href="examples/peakDetect_basic">peakDetect_basic</a></div>
-<div><a href="examples/peakDetection_offline">peakDetection_offline</a></div>
 <div><a href="examples/play_soundfile">play_soundfile</a></div>
 <div><a href="examples/playbackRate">playbackRate</a></div>
 <div><a href="examples/playbackRatePart">playbackRatePart</a></div>

--- a/src/looper.js
+++ b/src/looper.js
@@ -387,7 +387,7 @@ class Score {
   constructor() {
     // for all of the arguments
     this.parts = [];
-    this.currentPart = new Array(arguments.length);;
+    this.currentPart = new Array(arguments.length);
 
     var thisScore = this;
     for (var i in arguments) {
@@ -396,7 +396,7 @@ class Score {
       this.parts[i].onended = function () {
         thisScore.resetPart(i);
         playNextPart(thisScore);
-      };    
+      };
     }
     this.looping = false;
   }

--- a/src/soundRecorder.js
+++ b/src/soundRecorder.js
@@ -31,9 +31,6 @@ const ac = p5sound.audiocontext;
  *    // create an audio in
  *    mic = new p5.AudioIn();
  *
- *    // prompts user to enable their browser mic
- *    mic.start();
- *
  *    // create a sound recorder
  *    recorder = new p5.SoundRecorder();
  *
@@ -51,15 +48,17 @@ const ac = p5sound.audiocontext;
  *    // ensure audio is enabled
  *    userStartAudio();
  *
- *    // make sure user enabled the mic
- *    if (state === 0 && mic.enabled) {
+ *    if (state === 0) {
+ *    // make sure user enabled the mic by prompting to enable their browser mic
+ *    // start recording after the mic is enabled
+ *      mic.start(function() {
+ *        // record to our p5.SoundFile
+ *        recorder.record(soundFile);
  *
- *      // record to our p5.SoundFile
- *      recorder.record(soundFile);
- *
- *      background(255,0,0);
- *      text('Recording!', width/2, height/2);
- *      state++;
+ *        background(255,0,0);
+ *        text('Recording!', width/2, height/2);
+ *        state++;
+ *      });
  *    }
  *    else if (state === 1) {
  *      background(0,255,0);
@@ -67,6 +66,8 @@ const ac = p5sound.audiocontext;
  *      // stop recorder and
  *      // send result to soundFile
  *      recorder.stop();
+ *      // stop browser from accessing the mic
+ *      mic.dispose();
  *
  *      text('Done! Tap to play and download', width/2, height/2, width - 20);
  *      state++;

--- a/src/soundRecorder.js
+++ b/src/soundRecorder.js
@@ -20,8 +20,10 @@ const ac = p5sound.audiocontext;
  *  @example
  *  <div><code>
  *  let mic, recorder, soundFile;
- *  // mousePress will increment from state = 0 (Record), to 1(Stop), to 2(Play)
- *  let state = 0;
+ *  // keeps record if recording is started
+ *  let isRecordingStarted = false;
+ *  // keeps record if the recorded result is played
+ *  let isResultPlayed = false;
  *
  *  function setup() {
  *    let cnv = createCanvas(100, 100);
@@ -49,7 +51,7 @@ const ac = p5sound.audiocontext;
  *    // ensure audio is enabled
  *    userStartAudio();
  *
- *    if (state === 0) {
+ *    if (!isRecordingStarted && !isResultPlayed) {
  *    // make sure user enabled the mic by prompting to enable their browser mic
  *    // start recording after the mic is enabled
  *      mic.start(function() {
@@ -58,10 +60,10 @@ const ac = p5sound.audiocontext;
  *
  *        background(255,0,0);
  *        text('Recording!', width/2, height/2);
- *        state++;
+ *        isRecordingStarted = true;
  *      });
  *    }
- *    else if (state === 1) {
+ *    else if (isRecordingStarted && !isResultPlayed) {
  *      background(0,255,0);
  *
  *      // stop recorder and
@@ -71,10 +73,10 @@ const ac = p5sound.audiocontext;
  *      mic.dispose();
  *
  *      text('Done! Tap to play and download', width/2, height/2, width - 20);
- *      state++;
+ *      isResultPlayed = true;
  *    }
  *
- *    else if (state === 2) {
+ *    else if (isRecordingStarted && isResultPlayed) {
  *      soundFile.play(); // play the result!
  *      save(soundFile, 'mySound.wav');
  *    }

--- a/src/soundRecorder.js
+++ b/src/soundRecorder.js
@@ -20,6 +20,7 @@ const ac = p5sound.audiocontext;
  *  @example
  *  <div><code>
  *  let mic, recorder, soundFile;
+ *  // mousePress will increment from state = 0 (Record), to 1(Stop), to 2(Play)
  *  let state = 0;
  *
  *  function setup() {
@@ -76,7 +77,6 @@ const ac = p5sound.audiocontext;
  *    else if (state === 2) {
  *      soundFile.play(); // play the result!
  *      save(soundFile, 'mySound.wav');
- *      state++;
  *    }
  *  }
  *  </div></code>


### PR DESCRIPTION
Fixes #627,
Fixed the example in both the examples folder's file and also the inline code.

To make sure that the mic is called only after the user's interaction with the example, I've moved the mic setup code to the first click.
Also disposed the mic after the recording is completed.

##### Also adjusted the comments in the inline code accordingly and verified it by building locally.