### PR TITLE
Fix memory leak in Reverb set() method

### DIFF
--- a/src/reverb.js
+++ b/src/reverb.js
@@ -78,6 +78,7 @@ class Reverb extends Effect {
 
   _teardownConvolverNode() {
     if (this.convolverNode) {
+      this.input.disconnect(this.convolverNode);
       this.convolverNode.disconnect();
       delete this.convolverNode;
     }


### PR DESCRIPTION
This updates the Reverb `_teardownConvolverNode()` method to disconnect the convolver node from input in so it can be GC'd. Fixes #650.