### PR TITLE
Correct typo

### DIFF
--- a/src/listener3d.js
+++ b/src/listener3d.js
@@ -31,7 +31,7 @@ class Listener3D {
   }
 
   //  /**
-  //   * Connect an audio sorce
+  //   * Connect an audio source
   //   * @param  {Object} src Input source
   //   */
   process(src) {

--- a/src/panner3d.js
+++ b/src/panner3d.js
@@ -42,7 +42,7 @@ class Panner3D extends Effect {
   }
 
   /**
-   * Connect an audio sorce
+   * Connect an audio source
    *
    * @method  process
    * @for p5.Panner3D


### PR DESCRIPTION
I regenerated the library files after correcting the typo.

This commit fixes #634 and also replaces all the files in `lib/` directory with the latest code.  