### PR TITLE
fix inconsistency in documentation of effects

### DIFF
--- a/src/delay.js
+++ b/src/delay.js
@@ -114,7 +114,7 @@ class Delay extends Effect {
    *
    *  @method  process
    *  @for p5.Delay
-   *  @param  {Object} Signal  An object that outputs audio
+   *  @param  {Object} src An object that outputs audio
    *  @param  {Number} [delayTime] Time (in seconds) of the delay/echo.
    *                               Some browsers limit delayTime to
    *                               1 second.

--- a/src/effect.js
+++ b/src/effect.js
@@ -11,7 +11,9 @@ import CrossFade from 'Tone/component/CrossFade.js';
  * <a href="/reference/#/p5.Compressor">p5.Compressor</a>,
  * <a href="/reference/#/p5.Delay">p5.Delay</a>,
  * <a href="/reference/#/p5.Filter">p5.Filter</a>,
- * <a href="/reference/#/p5.Reverb">p5.Reverb</a>.
+ * <a href="/reference/#/p5.Reverb">p5.Reverb</a>,
+ * <a href="/reference/#/p5.EQ">p5.EQ</a>,
+ * <a href="/reference/#/p5.Panner3D">p5.Panner3D</a>.
  *
  * @class  p5.Effect
  * @constructor

--- a/src/filter.js
+++ b/src/filter.js
@@ -112,7 +112,7 @@ class Filter extends Effect {
    *  of filter parameters.
    *
    *  @method  process
-   *  @param  {Object} Signal  An object that outputs audio
+   *  @param {Object} src An object that outputs audio
    *  @param {Number} [freq] Frequency in Hz, from 10 to 22050
    *  @param {Number} [res] Resonance/Width of the filter frequency
    *                        from 0.001 to 1000

--- a/src/panner3d.js
+++ b/src/panner3d.js
@@ -12,8 +12,13 @@ import Effect from './effect';
  * Audio Context Listener</a>, which can be accessed
  * by <code>p5.soundOut.audiocontext.listener</code>
  *
+ *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+ *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+ *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
+ *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
  *
  * @class p5.Panner3D
+ * @extends p5.Effect
  * @constructor
  */
 

--- a/src/reverb.js
+++ b/src/reverb.js
@@ -212,6 +212,11 @@ class Reverb extends Effect {
  *  <p>Use the method <code>createConvolution(path)</code> to instantiate a
  *  p5.Convolver with a path to your impulse response audio file.</p>
  *
+ *  This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+ *  Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+ *  <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
+ *  <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
+ *
  *  @class p5.Convolver
  *  @extends p5.Effect
  *  @constructor


### PR DESCRIPTION
- renamed from "Signal" to "src" in Delay and Filter `process()` method documentation.
- added "This class extends [p5.Effect](https://p5js.org/reference/#/p5.Effect). Methods [amp()](https://p5js.org/reference/#/p5.Effect/amp), [chain()](https://p5js.org/reference/#/p5.Effect/chain), [drywet()](https://p5js.org/reference/#/p5.Effect/drywet), [connect()](https://p5js.org/reference/#/p5.Effect/connect), and [disconnect()](https://p5js.org/reference/#/p5.Effect/disconnect) are available." missing text in reverb and panner3d.
- added missing effects in the effect documentation.