### PR TITLE
fix compressor.reduction()

### DIFF
--- a/src/compressor.js
+++ b/src/compressor.js
@@ -235,7 +235,7 @@ class Compressor extends Effect {
    * @return {Number} Value of the amount of gain reduction that is applied to the signal
    */
   reduction() {
-    return this.compressor.reduction.value;
+    return this.compressor.reduction;
   }
 
   dispose() {

--- a/test/tests/p5.Compressor.js
+++ b/test/tests/p5.Compressor.js
@@ -110,7 +110,7 @@ describe('p5.Compressor', function () {
     });
     it('can return reduction value', function () {
       let compressor = new p5.Compressor();
-      let reduction = compressor.compressor.reduction.value;
+      let reduction = compressor.reduction();
       expect(reduction).to.not.be.null;
     });
     it('wet dry value can be changed', function () {


### PR DESCRIPTION
Resolves #710

- `Compressor.reduction()` now returns `this.compressor.reduction` instead of `this.compressor.reduction.value` since reduction doesn't have a value property
- test now uses `reduction()` instead of directly accesing the property with `compressor.compressor.reduction.value`