### PR TITLE
(Chore) : Fixed merge conflicts in "fixing EQ test"

### DIFF
--- a/test/tests/p5.EQ.js
+++ b/test/tests/p5.EQ.js
@@ -54,13 +54,17 @@ describe('p5.EQ', function () {
           }, 100);
         });
 
-        it("a band's freq value can be changed", function () {
+        it('a bands freq value can be changed', function (done) {
           const eq = new p5.EQ(8);
-          eq.bands[0].freq(200);
           setTimeout(() => {
-            expect(eq.bands[0].gain()).to.equal(0);
-            expect(eq.bands[0].freq()).to.equal(200);
-          }, 100);
+            expect(eq.bands[0].freq()).to.equal(100);
+            eq.bands[0].freq(200);
+            setTimeout(() => {
+              expect(eq.bands[0].gain()).to.equal(0);
+              expect(eq.bands[0].freq()).to.equal(200);
+              done();
+            }, 100);
+          }, 50);
         });
 
         it("a band's type can be changed", function () {


### PR DESCRIPTION
Signed-off-by: Abhijay Jain <Abhijay007j@gmail.com>

When we pass 8 in the EQ constructor it takes some time to initialize the freq but we are checking just after the setting that's why it is comparing with the default value i.e 350. Same issue when we are setting the freq to 200. 

Resolved merge conflicts in PR https://github.com/processing/p5.js-sound/pull/615

![117196347-fd230e00-ae03-11eb-96c0-b8b066d1ba23](https://user-images.githubusercontent.com/64387054/211070215-65ed302f-ece8-4a19-a0a2-1209db918992.png)
