### PR TITLE
fix FFT.getEnergy parameter validation

### DIFF
--- a/src/fft.js
+++ b/src/fft.js
@@ -350,9 +350,6 @@ class FFT {
       var index = Math.round((frequency1 / nyquist) * this.freqDomain.length);
       return this.freqDomain[index];
     }
-    if (frequency1 < 0 || frequency2 < 0) {
-      throw 'invalid input for getEnergy()';
-    }
 
     // if two parameters:
     // if second is higher than first

--- a/src/fft.js
+++ b/src/fft.js
@@ -344,38 +344,36 @@ class FFT {
 
     if (typeof frequency1 !== 'number') {
       throw 'invalid input for getEnergy()';
-    } else if (!frequency2) {
+    }
+    if (typeof frequency2 !== 'number') {
       // if only one parameter:
       var index = Math.round((frequency1 / nyquist) * this.freqDomain.length);
       return this.freqDomain[index];
-    } else if (frequency1 && frequency2) {
-      // if two parameters:
-      // if second is higher than first
-      if (frequency1 > frequency2) {
-        var swap = frequency2;
-        frequency2 = frequency1;
-        frequency1 = swap;
-      }
-      var lowIndex = Math.round(
-        (frequency1 / nyquist) * this.freqDomain.length
-      );
-      var highIndex = Math.round(
-        (frequency2 / nyquist) * this.freqDomain.length
-      );
-
-      var total = 0;
-      var numFrequencies = 0;
-      // add up all of the values for the frequencies
-      for (var i = lowIndex; i <= highIndex; i++) {
-        total += this.freqDomain[i];
-        numFrequencies += 1;
-      }
-      // divide by total number of frequencies
-      var toReturn = total / numFrequencies;
-      return toReturn;
-    } else {
+    }
+    if (frequency1 < 0 || frequency2 < 0) {
       throw 'invalid input for getEnergy()';
     }
+
+    // if two parameters:
+    // if second is higher than first
+    if (frequency1 > frequency2) {
+      var swap = frequency2;
+      frequency2 = frequency1;
+      frequency1 = swap;
+    }
+    var lowIndex = Math.round((frequency1 / nyquist) * this.freqDomain.length);
+    var highIndex = Math.round((frequency2 / nyquist) * this.freqDomain.length);
+
+    var total = 0;
+    var numFrequencies = 0;
+    // add up all of the values for the frequencies
+    for (var i = lowIndex; i <= highIndex; i++) {
+      total += this.freqDomain[i];
+      numFrequencies += 1;
+    }
+    // divide by total number of frequencies
+    var toReturn = total / numFrequencies;
+    return toReturn;
   }
 
   // compatability with v.012, changed to getEnergy in v.0121. Will be deprecated...


### PR DESCRIPTION
Addresses #665 (I am not closing the issue because I am not sure what should be done with negative numbers)

- `getEnergy()` now accepts 0 as a parameter
- Removed extra `else` statements
- Removed redundant `if`

