### PR TITLE
(Docs): Updated various fields in the `p5.MonoSynth` reference

### DIFF
--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -77,6 +77,9 @@ class MonoSynth extends AudioVoice {
      * @for p5.MonoSynth
      */
     /**
+     * used to set the decay time of the envelope (ADSR) of the MonoSynth class. 
+     * It is a getter and setter that can be used to retrieve or change the decay time. 
+     * It is used in conjunction with the attack, sustain, and release fields/functions to set the full envelope of the synthesizer.
      * @property {Number} decay
      * @for p5.MonoSynth
      */

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -77,17 +77,21 @@ class MonoSynth extends AudioVoice {
      * @for p5.MonoSynth
      */
     /**
-     * used to set the decay time of the envelope (ADSR) of the MonoSynth class. 
-     * It is a getter and setter that can be used to retrieve or change the decay time. 
-     * It is used in conjunction with the attack, sustain, and release fields/functions to set the full envelope of the synthesizer.
+     * allow user to set the decay time of the envelope (ADSR) of the MonoSynth class.
+     * It is a getter and setter that can be used to retrieve or change the decay time.
+     * used in conjunction with the attack, sustain, and release fields/functions to set the full envelope of the synthesizer.
      * @property {Number} decay
      * @for p5.MonoSynth
      */
     /**
+     * allows the user to retrieve and adjust the sustain level of the envelope,
+     * which controls the level at which the sound is sustained during the sustain phase of the envelope.
+     * The default sustain level is set to 0.15.
      * @property {Number} sustain
      * @for p5.MonoSynth
      */
     /**
+     * allows the user to access and change the release time of the envelope.
      * @property {Number} release
      * @for p5.MonoSynth
      */

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -77,21 +77,21 @@ class MonoSynth extends AudioVoice {
      * @for p5.MonoSynth
      */
     /**
-     * allow user to set the decay time of the envelope (ADSR) of the MonoSynth class.
+     * Allows user to set the decay time of the envelope (ADSR) of the MonoSynth class.
      * It is a getter and setter that can be used to retrieve or change the decay time.
-     * used in conjunction with the attack, sustain, and release fields/functions to set the full envelope of the synthesizer.
+     * Used in conjunction with the attack, sustain, and release fields/functions to set the full envelope of the synthesizer.
      * @property {Number} decay
      * @for p5.MonoSynth
      */
     /**
-     * allows the user to retrieve and adjust the sustain level of the envelope,
+     * Allows the user to retrieve and adjust the sustain level of the envelope,
      * which controls the level at which the sound is sustained during the sustain phase of the envelope.
      * The default sustain level is set to 0.15.
      * @property {Number} sustain
      * @for p5.MonoSynth
      */
     /**
-     * allows the user to access and change the release time of the envelope.
+     * Allows the user to access and change the release time of the envelope.
      * @property {Number} release
      * @for p5.MonoSynth
      */


### PR DESCRIPTION
Signed-off-by: Abhijay Jain <Abhijay007j@gmail.com>

added description for the various fields of `p5.MonoSynth reference` such as `decay`, `sustain` and `release`

resolves #727