### PR TITLE
`Panner.js` rework

### DIFF
--- a/src/effect.js
+++ b/src/effect.js
@@ -13,6 +13,7 @@ import CrossFade from 'Tone/component/CrossFade.js';
  * <a href="/reference/#/p5.Filter">p5.Filter</a>,
  * <a href="/reference/#/p5.Reverb">p5.Reverb</a>,
  * <a href="/reference/#/p5.EQ">p5.EQ</a>,
+ * <a href="/reference/#/p5.Panner">p5.Panner</a>.
  * <a href="/reference/#/p5.Panner3D">p5.Panner3D</a>.
  *
  * @class  p5.Effect

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -133,10 +133,14 @@ class Oscillator {
 
     this.oscillator.connect(this.output);
     // stereo panning
-    this.panPosition = 0.0;
     this.connection = p5sound.input; // connect to p5sound by default
-    this.panner = new Panner(this.output, this.connection, 1);
 
+    if (typeof p5sound.audiocontext.createStereoPanner !== 'undefined') {
+      this.panner = new Panner();
+      this.output.connect(this.panner);
+    } else {
+      this.panner = new Panner(this.output, this.connection, 1);
+    }
     //array of math operation signal chaining
     this.mathOps = [this.output];
 
@@ -415,21 +419,20 @@ class Oscillator {
    *                                seconds from now
    */
   pan(pval, tFromNow) {
-    this.panPosition = pval;
     this.panner.pan(pval, tFromNow);
   }
 
   /**
-   *  Returns the current value of panPosition , between Left (-1) and Right (1)
+   *  Returns the current value of pan position , between Left (-1) and Right (1)
    *
    *  @method  getPan
    *  @for p5.Oscillator
    *
-   *  @returns {number} panPosition of oscillator , between Left (-1) and Right (1)
+   *  @returns {number} pan position of oscillator , between Left (-1) and Right (1)
    */
 
   getPan() {
-    return this.panPosition;
+    return this.panner.getPan();
   }
 
   // get rid of the oscillator
@@ -442,7 +445,7 @@ class Oscillator {
       var now = p5sound.audiocontext.currentTime;
       this.stop(now);
       this.disconnect();
-      this.panner = null;
+      this.panner.dispose();
       this.oscillator = null;
     }
     // if it is a Pulse

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -446,6 +446,7 @@ class Oscillator {
       this.stop(now);
       this.disconnect();
       this.panner.dispose();
+      this.panner = null;
       this.oscillator = null;
     }
     // if it is a Pulse

--- a/src/panner.js
+++ b/src/panner.js
@@ -56,6 +56,7 @@ if (typeof ac.createStereoPanner !== 'undefined') {
       this.input = ac.createGain();
       input.connect(this.input);
 
+      this.panValue = 0;
       this.left = ac.createGain();
       this.right = ac.createGain();
       this.left.channelInterpretation = 'discrete';
@@ -81,6 +82,7 @@ if (typeof ac.createStereoPanner !== 'undefined') {
 
     // -1 is left, +1 is right
     pan(val, tFromNow) {
+      this.panValue = val;
       var time = tFromNow || 0;
       var t = ac.currentTime + time;
       var v = (val + 1) / 2;
@@ -88,6 +90,10 @@ if (typeof ac.createStereoPanner !== 'undefined') {
       var leftVal = Math.sin((v * Math.PI) / 2);
       this.left.gain.linearRampToValueAtTime(leftVal, t);
       this.right.gain.linearRampToValueAtTime(rightVal, t);
+    }
+
+    getPan() {
+      return this.panValue;
     }
 
     inputChannels(numChannels) {

--- a/src/panner.js
+++ b/src/panner.js
@@ -6,6 +6,19 @@ var panner;
 // Stereo panner
 // if there is a stereo panner node use it
 if (typeof ac.createStereoPanner !== 'undefined') {
+  /**
+   * The Panner class allows you to control the stereo
+   * panning of a sound source. It uses the [StereoPannerNode](https://developer.mozilla.org/en-US/docs/Web/API/StereoPannerNode),
+   * which allows you to adjust the balance between the left and right channels of a sound source.
+   *
+   * This class extends <a href = "/reference/#/p5.Effect">p5.Effect</a>.
+   * Methods <a href = "/reference/#/p5.Effect/amp">amp()</a>, <a href = "/reference/#/p5.Effect/chain">chain()</a>,
+   * <a href = "/reference/#/p5.Effect/drywet">drywet()</a>, <a href = "/reference/#/p5.Effect/connect">connect()</a>, and
+   * <a href = "/reference/#/p5.Effect/disconnect">disconnect()</a> are available.
+   *
+   * @class p5.Panner
+   * @extends p5.Effect
+   */
   class Panner extends Effect {
     constructor() {
       super();
@@ -15,6 +28,16 @@ if (typeof ac.createStereoPanner !== 'undefined') {
       this.stereoPanner.connect(this.wet);
     }
 
+    /**
+     * Set the stereo pan position, a value of -1 means the sound will be fully panned
+     * to the left, a value of 0 means the sound will be centered, and a value of 1 means
+     * the sound will be fully panned to the right.
+     * @method pan
+     * @for p5.Panner
+     * @param {Number} value  A value between -1 and 1 that sets the pan position.
+     *
+     * @param {Number} [time] time in seconds that it will take for the panning to change to the specified value.
+     */
     pan(val, tFromNow) {
       if (typeof val === 'number') {
         let time = tFromNow || 0;
@@ -27,10 +50,23 @@ if (typeof ac.createStereoPanner !== 'undefined') {
       }
     }
 
+    /**
+     *  Return the current panning value.
+     *
+     *  @method  getPan
+     *  @for p5.Panner
+     *  @return {Number} current panning value, number between -1 (left) and 1 (right).
+     */
     getPan() {
       return this.stereoPanner.pan.value;
     }
 
+    /**
+     *  Get rid of the Panner and free up its resources / memory.
+     *
+     *  @method  dispose
+     *  @for p5.Panner
+     */
     dispose() {
       super.dispose();
       if (this.stereoPanner) {

--- a/src/panner.js
+++ b/src/panner.js
@@ -43,7 +43,7 @@ if (typeof ac.createStereoPanner !== 'undefined') {
         let time = tFromNow || 0;
         this.stereoPanner.pan.linearRampToValueAtTime(
           val,
-          this.ac.currentTime + 0.02 + time
+          this.ac.currentTime + time
         );
       } else if (typeof val !== 'undefined') {
         val.connect(this.stereoPanner.pan);
@@ -155,6 +155,29 @@ if (typeof ac.createStereoPanner !== 'undefined') {
     disconnect() {
       if (this.output) {
         this.output.disconnect();
+      }
+    }
+
+    dispose() {
+      if (this.input) {
+        this.input.disconnect();
+        delete this.input;
+      }
+      if (this.output) {
+        this.output.disconnect();
+        delete this.output;
+      }
+      if (this.left) {
+        this.left.disconnect();
+        delete this.left;
+      }
+      if (this.right) {
+        this.right.disconnect();
+        delete this.right;
+      }
+      if (this.splitter) {
+        this.splitter.disconnect();
+        delete this.splitter;
       }
     }
   }

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -182,8 +182,12 @@ class SoundFile {
     this.startMillis = null;
 
     // stereo panning
-    this.panPosition = 0.0;
-    this.panner = new Panner(this.output, p5sound.input, 2);
+    if (typeof p5sound.audiocontext.createStereoPanner !== 'undefined') {
+      this.panner = new Panner();
+      this.output.connect(this.panner);
+    } else {
+      this.panner = new Panner(this.output, p5sound.input, 2);
+    }
 
     // it is possible to instantiate a soundfile with no path
     if (this.url || this.file) {
@@ -795,7 +799,6 @@ class SoundFile {
    *  </div></code>
    */
   pan(pval, tFromNow) {
-    this.panPosition = pval;
     this.panner.pan(pval, tFromNow);
   }
 
@@ -809,7 +812,7 @@ class SoundFile {
    *                          0.0 is center and default.
    */
   getPan() {
-    return this.panPosition;
+    return this.panner.getPan();
   }
 
   /**
@@ -1264,7 +1267,7 @@ class SoundFile {
       this.output = null;
     }
     if (this.panner) {
-      this.panner.disconnect();
+      this.panner.dispose();
       this.panner = null;
     }
   }

--- a/test/tests/p5.Oscillator.js
+++ b/test/tests/p5.Oscillator.js
@@ -216,11 +216,8 @@ describe('p5.Oscillator', function () {
     it('can be panned without any delay', function (done) {
       let osc = new p5.Oscillator();
       let panner = osc.panner;
-      expect(osc.panPosition).to.equal(0); //default value
       expect(osc.getPan()).to.equal(0);
       osc.pan(-0.3);
-      expect(osc.panPosition).to.equal(-0.3);
-      expect(osc.getPan()).to.equal(-0.3);
       if (typeof p5.soundOut.audiocontext.createStereoPanner !== 'undefined') {
         setTimeout(() => {
           expect(panner.stereoPanner.pan.value).to.be.approximately(-0.3, 0.01);
@@ -238,8 +235,6 @@ describe('p5.Oscillator', function () {
       let osc = new p5.Oscillator();
       osc.pan(0.7, 0.1);
       let panner = osc.panner;
-      expect(osc.panPosition).to.equal(0.7);
-      expect(osc.getPan()).to.equal(0.7);
       if (typeof p5.soundOut.audiocontext.createStereoPanner !== 'undefined') {
         setTimeout(() => {
           expect(panner.stereoPanner.pan.value).to.not.be.approximately(
@@ -252,7 +247,7 @@ describe('p5.Oscillator', function () {
               0.01
             );
             done();
-          }, 50);
+          }, 60);
         }, 50);
       } else {
         setTimeout(() => {
@@ -268,7 +263,7 @@ describe('p5.Oscillator', function () {
             expect(panner.left.gain.value).to.be.approximately(0.972, 0.001);
             expect(panner.right.gain.value).to.be.approximately(0.233, 0.001);
             done();
-          }, 100);
+          }, 60);
         }, 50);
       }
     });

--- a/test/tests/p5.Panner.js
+++ b/test/tests/p5.Panner.js
@@ -1,4 +1,4 @@
-// const expect = chai.expect;
+const expect = chai.expect;
 
 describe('p5.Panner', function () {
   let ac, output, input;
@@ -8,22 +8,28 @@ describe('p5.Panner', function () {
     input = ac.createGain();
   });
   it('can be created', function () {
-    new p5.Panner(input, output);
+    new p5.Panner();
   });
   it('can be connected and disconnected', function () {
-    let panner = new p5.Panner(input, output);
+    let panner = new p5.Panner();
     panner.connect(input);
     panner.disconnect();
   });
-  it('can be panned without a delay', function () {
-    let panner = new p5.Panner(input, output);
+  it('can be panned without a delay', function (done) {
+    let panner = new p5.Panner();
     panner.pan(0.4);
-    panner.pan(0.3, 0);
-    //TODO: to check the value of left gain/ right gain (or) the stereoPanner.pan
+    setTimeout(() => {
+      expect(panner.getPan()).to.be.approximately(0.4, 0.01);
+      done();
+    }, 25);
   });
-  it('can be panned with a delay', function () {
+  it('can be panned with a delay', function (done) {
     let panner = new p5.Panner(input, output);
-    panner.pan(0.4, 10);
+    panner.pan(-0.7, 0.1);
+    setTimeout(() => {
+      expect(panner.getPan()).to.be.approximately(-0.7, 0.01);
+      done();
+    }, 125);
   });
   it('can take inputChannels as 1 or 2', function () {
     let panner = new p5.Panner(input, output);

--- a/test/tests/p5.SoundFile.js
+++ b/test/tests/p5.SoundFile.js
@@ -30,7 +30,7 @@ describe('p5.SoundFile', function () {
     expect(sf.pauseTime).to.equal(0);
     expect(sf.mode).to.equal('sustain');
     expect(sf.startMillis).to.be.null;
-    expect(sf.panPosition).to.equal(0);
+    expect(sf.getPan()).to.equal(0);
     expect(sf.panner).to.have.property('stereoPanner');
     expect(p5.soundOut.soundArray).to.include(sf);
 
@@ -507,13 +507,13 @@ describe('p5.SoundFile', function () {
       let sf = new p5.SoundFile();
       expect(sf.getPan()).to.equal(0);
       sf.pan(0.32);
-      expect(sf.panPosition).to.equal(0.32);
-      expect(sf.getPan()).to.equal(0.32);
+      setTimeout(() => {
+        expect(sf.getPan()).to.equal(0.32);
+      }, 5);
       //with delay
       let sf2 = new p5.SoundFile();
       sf2.pan(-0.89, 0.1);
       setTimeout(() => {
-        expect(sf2.panPosition).to.equal(-0.89);
         expect(sf2.getPan()).to.equal(-0.89);
       }, 100);
     });


### PR DESCRIPTION
Adresses #723, #303 

- `Panner.js` now extends `Effect.js`
- Added `getPan()` and `dispose()` methods to `Panner.js` 
- Modified `Oscillator.js` and `SoundFile.js` to work with the updated `Panner.js`
- Added documentation  and tests for `Panner.js`

For now, the `Panner.js` fallback for safari only works when used internally by `Oscillator.js` and `SoundFile.js`, does not extend `Effect.js` and does not have a `dispose()` method.