### PR TITLE
add `_onNewInput()` hook 

### DIFF
--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -177,25 +177,6 @@ class Amplitude {
     }
   }
 
-  connect(unit) {
-    if (unit) {
-      if (unit.hasOwnProperty('input')) {
-        this.output.connect(unit.input);
-      } else {
-        this.output.connect(unit);
-      }
-    }
-    // else {
-    //   this.output.connect(this.panner.connect(p5sound.input));
-    // }
-  }
-
-  disconnect() {
-    if (this.output) {
-      this.output.disconnect();
-    }
-  }
-
   /**
    *  Returns a single Amplitude reading at the moment it is called.
    *  For continuous readings, run in the draw loop.

--- a/src/audioVoice.js
+++ b/src/audioVoice.js
@@ -34,6 +34,9 @@ class AudioVoice {
   connect(unit) {
     var u = unit || p5sound.input;
     this.output.connect(u.input ? u.input : u);
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**

--- a/src/audioin.js
+++ b/src/audioin.js
@@ -211,6 +211,9 @@ class AudioIn {
     } else {
       this.output.connect(p5sound.input);
     }
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**
@@ -395,7 +398,7 @@ class AudioIn {
       this.output.disconnect();
     }
     if (this.amplitude) {
-      this.amplitude.disconnect();
+      this.amplitude.dispose();
     }
     delete this.amplitude;
     delete this.output;

--- a/src/effect.js
+++ b/src/effect.js
@@ -122,6 +122,9 @@ class Effect {
   connect(unit) {
     var u = unit || p5.soundOut.input;
     this.output.connect(u.input ? u.input : u);
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**

--- a/src/envelope.js
+++ b/src/envelope.js
@@ -810,6 +810,9 @@ class Envelope {
     }
 
     this.output.connect(unit);
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   disconnect() {

--- a/src/fft.js
+++ b/src/fft.js
@@ -614,6 +614,11 @@ class FFT {
 
     return octaveBands;
   }
+
+  _onNewInput() {
+    //  disconnect FFT from sketch when something is connected
+    p5sound.fftMeter.disconnect();
+  }
 }
 
 // helper methods to convert type from float (dB) to int (0-255)

--- a/src/gain.js
+++ b/src/gain.js
@@ -106,6 +106,9 @@ class Gain {
   connect(unit) {
     var u = unit || p5.soundOut.input;
     this.output.connect(u.input ? u.input : u);
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**

--- a/src/monosynth.js
+++ b/src/monosynth.js
@@ -355,6 +355,9 @@ class MonoSynth extends AudioVoice {
   connect(unit) {
     var u = unit || p5sound.input;
     this.output.connect(u.input ? u.input : u);
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**

--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -387,6 +387,9 @@ class Oscillator {
       this.panner.connect(unit);
       this.connection = unit;
     }
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**

--- a/src/panner.js
+++ b/src/panner.js
@@ -150,6 +150,9 @@ if (typeof ac.createStereoPanner !== 'undefined') {
 
     connect(obj) {
       this.output.connect(obj);
+      if (obj && obj._onNewInput) {
+        obj._onNewInput(this);
+      }
     }
 
     disconnect() {

--- a/src/polysynth.js
+++ b/src/polysynth.js
@@ -428,6 +428,9 @@ class PolySynth {
   connect(unit) {
     var u = unit || p5sound.input;
     this.output.connect(u.input ? u.input : u);
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -1293,6 +1293,9 @@ class SoundFile {
         this.panner.connect(unit);
       }
     }
+    if (unit && unit._onNewInput) {
+      unit._onNewInput(this);
+    }
   }
 
   /**

--- a/test/tests/p5.Amplitude.js
+++ b/test/tests/p5.Amplitude.js
@@ -41,21 +41,6 @@ describe('p5.Amplitude', function () {
       amp.setInput();
     });
 
-    it('can be connected and disconnected from a unit', function () {
-      let filter = new p5.Filter();
-
-      //if unit has input property
-      amp.connect(filter);
-      amp.disconnect();
-
-      //if unit doesnot have an input property
-      amp = new p5.Amplitude();
-      amp.connect(filter.input);
-      amp.disconnect();
-
-      filter.dispose();
-    });
-
     it('can toggle normalization', function () {
       expect(amp.normalize).to.be.false;
       amp.toggleNormalize();

--- a/test/tests/p5.AudioIn.js
+++ b/test/tests/p5.AudioIn.js
@@ -109,5 +109,13 @@ describe('p5.AudioIn', function () {
         done();
       });
     });
+
+    it('can execute _onNewInput() hook on connected unit', function (done) {
+      const gain = new p5.Gain();
+      gain._onNewInput = function () {
+        done();
+      };
+      mic.connect(gain);
+    });
   });
 });

--- a/test/tests/p5.AudioVoice.js
+++ b/test/tests/p5.AudioVoice.js
@@ -25,4 +25,12 @@ describe('p5.AudioVoice', function () {
     av.connect(filter.input);
     av.disconnect();
   });
+  it('can execute _onNewInput() hook on connected unit', function (done) {
+    let av = new p5.AudioVoice();
+    const gain = new p5.Gain();
+    gain._onNewInput = function () {
+      done();
+    };
+    av.connect(gain);
+  });
 });

--- a/test/tests/p5.Effect.js
+++ b/test/tests/p5.Effect.js
@@ -81,5 +81,13 @@ describe('p5.Effect', function () {
       expect(effect._drywet.fade.value).to.equal(0.5);
       expect(effect.drywet()).to.equal(0.5);
     });
+    it('can execute _onNewInput() hook on connected unit', function (done) {
+      const effect = new p5.Effect();
+      const gain = new p5.Gain();
+      gain._onNewInput = function () {
+        done();
+      };
+      effect.connect(gain);
+    });
   });
 });

--- a/test/tests/p5.Envelope.js
+++ b/test/tests/p5.Envelope.js
@@ -264,6 +264,14 @@ describe('p5.Envelope', function () {
       envelope.connect(reverb.output.gain);
       envelope.disconnect();
     });
+    it('can execute _onNewInput() hook on connected unit', function (done) {
+      let envelope = new p5.Envelope(0.1, 0.65, 0.5, 0.5, 0.35, 0.4);
+      const gain = new p5.Gain();
+      gain._onNewInput = function () {
+        done();
+      };
+      envelope.connect(gain);
+    });
 
     //todo: signal math
   });

--- a/test/tests/p5.Gain.js
+++ b/test/tests/p5.Gain.js
@@ -59,6 +59,13 @@ describe('p5.Gain', function () {
         gain.connect(filter);
         gain.disconnect();
       });
+      it('can execute _onNewInput() hook on connected unit', function (done) {
+        const gainToConnect = new p5.Gain();
+        gainToConnect._onNewInput = function () {
+          done();
+        };
+        gain.connect(gainToConnect);
+      });
     });
     describe('amp', function () {
       it('can take only volume as input', function () {

--- a/test/tests/p5.MonoSynth.js
+++ b/test/tests/p5.MonoSynth.js
@@ -207,5 +207,13 @@ describe('p5.MonoSynth', function () {
       monosynth.connect(compressor);
       monosynth.disconnect();
     });
+    it('can execute _onNewInput() hook on connected unit', function (done) {
+      let monosynth = new p5.MonoSynth();
+      const gain = new p5.Gain();
+      gain._onNewInput = function () {
+        done();
+      };
+      monosynth.connect(gain);
+    });
   });
 });

--- a/test/tests/p5.Oscillator.js
+++ b/test/tests/p5.Oscillator.js
@@ -292,5 +292,13 @@ describe('p5.Oscillator', function () {
       osc.add(3).mult(5);
       osc.scale(0, 1, 0, 4);
     });
+    it('can execute _onNewInput() hook on connected unit', function (done) {
+      let osc = new p5.Oscillator();
+      const gain = new p5.Gain();
+      gain._onNewInput = function () {
+        done();
+      };
+      osc.connect(gain);
+    });
   });
 });

--- a/test/tests/p5.Panner.js
+++ b/test/tests/p5.Panner.js
@@ -36,4 +36,12 @@ describe('p5.Panner', function () {
     panner.inputChannels(1);
     panner.inputChannels(2);
   });
+  it('can execute _onNewInput() hook on connected unit', function (done) {
+    let panner = new p5.Panner(input, output);
+    const gain = new p5.Gain();
+    gain._onNewInput = function () {
+      done();
+    };
+    panner.connect(gain);
+  });
 });

--- a/test/tests/p5.PolySynth.js
+++ b/test/tests/p5.PolySynth.js
@@ -294,5 +294,13 @@ describe('p5.PolySynth', function () {
       polySynth.connect(compressor);
       polySynth.disconnect();
     });
+    it('can execute _onNewInput() hook on connected unit', function (done) {
+      let polySynth = new p5.PolySynth(p5.MonoSynth, 4);
+      const gain = new p5.Gain();
+      gain._onNewInput = function () {
+        done();
+      };
+      polySynth.connect(gain);
+    });
   });
 });

--- a/test/tests/p5.SoundFile.js
+++ b/test/tests/p5.SoundFile.js
@@ -882,5 +882,14 @@ describe('p5.SoundFile', function () {
         expect(sf.getBlob().type).to.equal('audio/wav');
       });
     });
+
+    it('can execute _onNewInput() hook on connected unit', function (done) {
+      let sf = new p5.SoundFile();
+      const gain = new p5.Gain();
+      gain._onNewInput = function () {
+        done();
+      };
+      sf.connect(gain);
+    });
   });
 });


### PR DESCRIPTION
Closes #737 

- Classes with `connect(unit)` method now call `unit._onNewInput()` .
- Added `FFT._onNewInput()` so that FFT.js stops listening to all sound in the sketch when something is connected to it.
- Added tests for `._onNewInput()`.
