### PR TITLE
update `Panner.js` fallback to extend `Effect.js`

### DIFF
--- a/src/oscillator.js
+++ b/src/oscillator.js
@@ -135,12 +135,8 @@ class Oscillator {
     // stereo panning
     this.connection = p5sound.input; // connect to p5sound by default
 
-    if (typeof p5sound.audiocontext.createStereoPanner !== 'undefined') {
-      this.panner = new Panner();
-      this.output.connect(this.panner);
-    } else {
-      this.panner = new Panner(this.output, this.connection, 1);
-    }
+    this.panner = new Panner();
+    this.output.connect(this.panner);
     //array of math operation signal chaining
     this.mathOps = [this.output];
 

--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -182,12 +182,8 @@ class SoundFile {
     this.startMillis = null;
 
     // stereo panning
-    if (typeof p5sound.audiocontext.createStereoPanner !== 'undefined') {
-      this.panner = new Panner();
-      this.output.connect(this.panner);
-    } else {
-      this.panner = new Panner(this.output, p5sound.input, 2);
-    }
+    this.panner = new Panner();
+    this.output.connect(this.panner);
 
     // it is possible to instantiate a soundfile with no path
     if (this.url || this.file) {
@@ -248,7 +244,6 @@ class SoundFile {
             function (buff) {
               if (!self.panner) return;
               self.buffer = buff;
-              self.panner.inputChannels(buff.numberOfChannels);
               if (callback) {
                 callback(self);
               }
@@ -323,7 +318,6 @@ class SoundFile {
         ac.decodeAudioData(reader.result, function (buff) {
           if (!self.panner) return;
           self.buffer = buff;
-          self.panner.inputChannels(buff.numberOfChannels);
           if (callback) {
             callback(self);
           }
@@ -1357,9 +1351,6 @@ class SoundFile {
     }
 
     this.buffer = newBuffer;
-
-    // set numbers of channels on input to the panner
-    this.panner.inputChannels(numChannels);
   }
 
   // initialize counterNode, set its initial buffer and playbackRate

--- a/test/tests/p5.Panner.js
+++ b/test/tests/p5.Panner.js
@@ -1,10 +1,9 @@
 const expect = chai.expect;
 
 describe('p5.Panner', function () {
-  let ac, output, input;
+  let ac, input;
   beforeEach(function () {
     ac = p5.prototype.getAudioContext();
-    output = ac.createGain();
     input = ac.createGain();
   });
   it('can be created', function () {
@@ -24,24 +23,11 @@ describe('p5.Panner', function () {
     }, 25);
   });
   it('can be panned with a delay', function (done) {
-    let panner = new p5.Panner(input, output);
+    let panner = new p5.Panner();
     panner.pan(-0.7, 0.1);
     setTimeout(() => {
       expect(panner.getPan()).to.be.approximately(-0.7, 0.01);
       done();
     }, 125);
-  });
-  it('can take inputChannels as 1 or 2', function () {
-    let panner = new p5.Panner(input, output);
-    panner.inputChannels(1);
-    panner.inputChannels(2);
-  });
-  it('can execute _onNewInput() hook on connected unit', function (done) {
-    let panner = new p5.Panner(input, output);
-    const gain = new p5.Gain();
-    gain._onNewInput = function () {
-      done();
-    };
-    panner.connect(gain);
   });
 });

--- a/test/tests/p5.SoundFile.js
+++ b/test/tests/p5.SoundFile.js
@@ -31,7 +31,7 @@ describe('p5.SoundFile', function () {
     expect(sf.mode).to.equal('sustain');
     expect(sf.startMillis).to.be.null;
     expect(sf.getPan()).to.equal(0);
-    expect(sf.panner).to.have.property('stereoPanner');
+    expect(sf).to.have.property('panner');
     expect(p5.soundOut.soundArray).to.include(sf);
 
     expect(sf._whileLoading).to.not.throw();


### PR DESCRIPTION
Closes #723 Adresses #303 

- The `Panner.js` fallback for safari<14.1 now works the same way as regular `Panner.js`, I think the only difference is that the `Panner.js` fallback does not accept an AudioParam to be connected in the `Panner.pan()` method.
- Updated `Oscillator.js` and `SoundFile.js` to work with `Panner.js`.
- Updated Tests.
