### PR TITLE
Update error message to playMode

### DIFF
--- a/src/soundfile.js
+++ b/src/soundfile.js
@@ -527,7 +527,7 @@ class SoundFile {
     if (s === 'restart' || s === 'sustain' || s === 'untildone') {
       this.mode = s;
     } else {
-      throw 'Invalid play mode. Must be either "restart" or "sustain"';
+      throw 'Invalid play mode. Must be either "restart", "sustain" or "untildone';
     }
   }
 


### PR DESCRIPTION
Error thrown when using playMode with an invalid string does not mention "untildone" as an option.



